### PR TITLE
Reduce the WARNING during building and running it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring.boot-version}</version>
 				<configuration>
 					<executable>true</executable>
 				</configuration>


### PR DESCRIPTION
Hi Kunal,

Following your instruction, and I saw the following WARNING when I build and run the SpringBoot. I did a very small modification on pom.xml file to reduce this warning message. Please look at this small change, and let me know

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.epics:ChannelFinder:jar:4.0.0
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 121, column 12
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```