### PR TITLE
Add builtin Manager webpage

### DIFF
--- a/src/main/java/gov/bnl/channelfinder/ChannelManager.java
+++ b/src/main/java/gov/bnl/channelfinder/ChannelManager.java
@@ -14,6 +14,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,6 +28,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import gov.bnl.channelfinder.AuthorizationService.ROLES;
 
+@CrossOrigin
 @RestController
 @RequestMapping(CHANNEL_RESOURCE_URI)
 @EnableAutoConfiguration

--- a/src/main/java/gov/bnl/channelfinder/ChannelScroll.java
+++ b/src/main/java/gov/bnl/channelfinder/ChannelScroll.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,6 +46,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.bnl.channelfinder.XmlProperty.OnlyXmlProperty;
 import gov.bnl.channelfinder.XmlTag.OnlyXmlTag;
 
+@CrossOrigin
 @RestController
 @RequestMapping(SCROLL_RESOURCE_URI)
 @EnableAutoConfiguration

--- a/src/main/java/gov/bnl/channelfinder/InfoManager.java
+++ b/src/main/java/gov/bnl/channelfinder/InfoManager.java
@@ -16,6 +16,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+@CrossOrigin
 @RestController
 @RequestMapping(CF_SERVICE_INFO)
 @EnableAutoConfiguration

--- a/src/main/java/gov/bnl/channelfinder/PropertyManager.java
+++ b/src/main/java/gov/bnl/channelfinder/PropertyManager.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,6 +29,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import gov.bnl.channelfinder.AuthorizationService.ROLES;
 
+@CrossOrigin
 @RestController
 @RequestMapping(PROPERTY_RESOURCE_URI)
 @EnableAutoConfiguration

--- a/src/main/java/gov/bnl/channelfinder/TagManager.java
+++ b/src/main/java/gov/bnl/channelfinder/TagManager.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,6 +30,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import gov.bnl.channelfinder.AuthorizationService.ROLES;
 
+@CrossOrigin
 @RestController
 @RequestMapping(TAG_RESOURCE_URI)
 @EnableAutoConfiguration

--- a/src/main/resources/static/cf.js
+++ b/src/main/resources/static/cf.js
@@ -1,0 +1,191 @@
+
+"use strict";
+
+var ChannelFinder = (function() {
+
+function ChannelFinder(opts) {
+    opts = opts || {};
+    this.baseurl = opts.baseurl || "/ChannelFinder";
+}
+
+function doReq(suffix, opts) {
+    opts = opts || {};
+    opts.headers = opts.headers || new Headers();
+    opts.cache = "no-cache";
+    if(opts.json) {
+        opts.body = JSON.stringify(opts.json);
+        opts.headers.append("Content-Type", "application/json");
+        delete opts.json;
+    }
+    const req = new Request(this.baseurl + suffix, opts);
+    return fetch(req)
+    .then(resp => {
+        if(!resp.ok) {
+            if(resp.headers.get("Content-Type").startsWith("application/json")) {
+                return resp.json().then(json => {
+                    throw new Error(json.error+" : "+json.message);
+                });
+            }
+            throw new Error(resp.status+" "+resp.url);
+        }
+        return resp;
+    });
+}
+
+/* Return Promise yielding the server info Object
+ */
+ChannelFinder.prototype.info = function() {
+    return doReq.call(this, "").then(resp => resp.json());
+};
+
+/* Return a Promise yielding an Array of tags.  [{name:"", owner:""}]
+ */
+ChannelFinder.prototype.tags = function() {
+    return doReq.call(this, "/resources/tags").then(resp => resp.json());
+}
+
+/* Return a Promise yielding an Array of properties.  [{name:"", owner:""}]
+ */
+ChannelFinder.prototype.properties = function() {
+    return doReq.call(this, "/resources/properties").then(resp => resp.json());
+}
+
+ChannelFinder.prototype.query = function(args) {
+    const Q = new URLSearchParams();
+    if(args.pattern) {
+        Q.append("~name", args.pattern);
+    }
+    for(const tag of args.tags || []) {
+        Q.append("~tag", tag);
+    }
+    for(const prop in args.properties || {}) {
+        Q.append(prop, args.properties[prop]);
+    }
+    if(args.size) {
+        Q.append("~size", args.size);
+    }
+    if(args.from) {
+        Q.append("~from", args.from);
+    }
+    return doReq.call(this, "/resources/channels?" + Q.toString()).then(resp => resp.json());
+}
+
+/* Create a channel, tag, or property.
+ * Return a Promise yielding the created channel, tag, or property
+ */
+ChannelFinder.prototype.create = function(args) {
+    if(args.tag) {
+        return doReq.call(this, "/resources/tags/" + args.tag, {
+            method: "PUT",
+            json: {name: args.tag, owner:args.owner},
+        });
+
+    } else if(args.property) {
+        return doReq.call(this, "/resources/properties/" + args.property, {
+            method: "PUT",
+            json: {name: args.property, owner:args.owner},
+        });
+
+    } else if(args.channels) {
+        return doReq.call(this, "/resources/channels", {
+            method: "PUT",
+            json: args.channels.map(chan => {
+                const ent = {name:chan.name, owner:args.owner, tags:[], properties:[]};
+                for(const tag of chan.tags) {
+                    ent.tags.push({name:tag});
+                }
+                for(const prop in chan.properties) {
+                    ent.properties.push({name:prop, value:chan.properties[prop]});
+                }
+                return ent;
+            }),
+        });
+
+    } else {
+        throw new Error("missing required argument");
+    }
+}
+
+/* Delete a channel, tag, or property.
+ * Return a Promise yielding nothing.
+ */
+ChannelFinder.prototype.delete = function(args) {
+    if(args.tag) {
+        return doReq.call(this, "/resources/tags/" + args.tag, {
+            method: "DELETE",
+        });
+
+    } else if(args.property) {
+        return doReq.call(this, "/resources/properties/" + args.property, {
+            method: "DELETE",
+        });
+
+    } else if(args.channel) {
+        return doReq.call(this, "/resources/channels/" + args.channel, {
+            method: "DELETE",
+        });
+
+    } else {
+        throw new Error("missing required argument");
+    }
+}
+
+/* Apply a tag or property to a channel or channels */
+ChannelFinder.prototype.apply = function(args) {
+    const channels = args.channels || [args.channel];
+    if(args.tag || args.property) {
+        var url;
+        const ent = {owner:args.owner};
+        if(args.tag) {
+            url = "/resources/tags/" + args.tag;
+            ent.name = args.tag;
+
+        } else if(args.property) {
+            url = "/resources/properties/" + args.property;
+            ent.name = args.property;
+        }
+
+        ent.channels = channels.map(chan => {
+            const ret = {name:chan, owner:args.owner};
+            if(args.property) {
+                ret.properties = [{name:args.property, value:args.value, owner:args.owner}];
+            }
+            return ret;
+        });
+
+        return doReq.call(this, url, {
+            method: "POST",
+            json: ent,
+        });
+
+    } else {
+        throw new Error("missing required argument");
+    }
+}
+
+/* Remove a tag or property from a channel or channels */
+ChannelFinder.prototype.remove = function(args) {
+    const channels = args.channels || [args.channel];
+    if(args.tag || args.property) {
+        return channels.reduce((P, chan) => {
+            return P.then(() => {
+                var url;
+                if(args.tag) {
+                    url = "/resources/tags/" + args.tag + "/" + chan;
+
+                } else if(args.property) {
+                    url = "/resources/properties/" + args.property + "/" + chan;
+                }
+                return doReq.call(this, url, {
+                    method: "DELETE",
+                });
+            });
+        }, Promise.resolve());
+
+    } else {
+        throw new Error("missing required argument");
+    }
+}
+
+return ChannelFinder;
+})();

--- a/src/main/resources/static/cfmanage.css
+++ b/src/main/resources/static/cfmanage.css
@@ -1,0 +1,77 @@
+html {
+    font-size: 100%;
+    font-family: Verdana, Arial, Helvetica, sans-serif;
+}
+
+body {
+    background-color: #ddd;
+}
+
+.cf-pane {
+    padding: 1ex;
+    border-radius: 1ex;
+    margin-bottom: 1ex;
+    background-color: #f1fcff;
+    background: linear-gradient(45deg, #f1fcff, #daebf0);
+}
+
+.cf-chan {
+    padding: 0.1ex;
+    border-radius: 0.5ex;
+    background-color: lightgreen;
+}
+
+.cf-tagprop {
+    padding: 0.1ex;
+    border-radius: 0.5ex;
+    background-color: lightblue;
+}
+
+.cf-value {
+    padding: 0.1ex;
+    border-radius: 0.5ex;
+    background-color: aquamarine;
+}
+
+.cf-owner {
+    padding: 0.1ex;
+    border-radius: 0.5ex;
+    background-color: lightcyan;
+}
+
+.cf-error {
+    color: red;
+}
+
+button, input[type=submit] {
+    border-radius: 0.5ex;
+}
+
+.cf-list {
+    list-style-type: disclosure-closed;
+}
+
+.cf-list li {
+    padding-bottom: 0.3ex;
+}
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltext {
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+ 
+  position: absolute;
+  z-index: 1;
+}
+.tooltip:hover .tooltext {
+  visibility: visible;
+}

--- a/src/main/resources/static/cfmanage.js
+++ b/src/main/resources/static/cfmanage.js
@@ -1,0 +1,251 @@
+"use strict";
+
+const CF = new ChannelFinder();
+
+function updateInfo() {
+    const elem = document.getElementById("servinfo");
+    CF.info()
+    .then(info => {
+        elem.innerText = JSON.stringify(info);
+    })
+    .catch(exc => {
+        console.error(exc);
+        elem.innerText = exc;
+    });
+}
+
+function getOwner() {
+    return document.getElementById("ownertxt").value;
+}
+
+function addChild(parent, elem, args) {
+    args = args || {};
+    if(args.tip) {
+        parent = parent.appendChild(document.createElement("div"));
+        parent.classList.add("tooltip");
+    }
+    const child = parent.appendChild(document.createElement(elem));
+    if(args.klass) {
+        child.classList.add(args.klass);
+    }
+    if(args.tip) {
+        const tip = parent.appendChild(document.createElement("span"));
+        tip.classList.add("tooltext");
+        tip.innerText = args.tip;
+    }
+    return child;
+}
+
+function doQuery() {
+    const query = document.getElementById("querytxt").value;
+    // clear previous results
+    const results = document.getElementById("queryresult");
+    while(results.firstChild) {
+        results.removeChild(results.firstChild);
+    }
+
+    const parts = query.split(" ").map(part => part.trim()).filter(part => part.length>0);
+    if(parts.length==0) {
+        return;
+    }
+    const Q = {pattern:parts.shift(), tags:[], properties:{}, size:1024};
+    for(const part of parts) {
+        const [key, val] = part.split("=", 2);
+        if(val===undefined) {
+            Q.tags.push(key);
+        } else {
+            Q.properties[key] = val;
+        }
+    }
+
+    CF.query(Q)
+    .then(channels => {
+        results.replaceChildren(...channels.map(ent => {
+            const li = document.createElement("li");
+
+            addChild(li, "span", {klass:"cf-chan", tip:"owner "+ent.owner}).innerText = ent.name;
+
+            li.append("  ");
+
+            for(const tag of ent.tags || []) {
+                addChild(li, "span", {klass:"cf-tagprop", tip:"owner "+tag.owner}).innerText = tag.name;
+                li.append(" ");
+            }
+
+            for(const prop of ent.properties || []) {
+                addChild(li, "span", {klass:"cf-tagprop", tip:"owner "+prop.owner}).innerText = prop.name;
+                li.append("=");
+                addChild(li, "span", {klass:"cf-value"}).innerText = prop.value;
+                li.append(" ");
+            }
+
+            return li;
+        }));
+    })
+    .catch(exc => {
+        console.error(exc);
+        const li = addChild(results, "li");
+        addChild(li, "span", {klass:"cf-error"}).innerText = exc.message;
+    });
+}
+
+function createChannels() {
+    const err = document.getElementById("chanerr");
+    const channels = document.getElementById("chanlist").value
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.length>0)
+    .map(line => {
+        const parts = line.split(" ");
+        const ent = {name:parts.shift(), tags:[], properties:{}};
+        for(const part of parts) {
+            const [key, val] = part.split("=", 2);
+            if(val===undefined) {
+                ent.tags.push(key);
+            } else {
+                ent.properties[key] = val;
+            }
+        }
+        return ent;
+    });
+
+    if(channels.length) {
+        CF.create({channels:channels, owner:getOwner()})
+        .then(() => {
+            err.innerText = "";
+        })
+        .catch(exc => {
+            err.innerText = exc.message;
+        });
+    }
+}
+
+function deleteChannels() {
+    const err = document.getElementById("chanerr");
+    // delete channels individually, and in sequence (to avoid thundering hurd)
+    document.getElementById("chanlist").value
+    .split("\n")
+    .reduce((P, chan) => {
+        chan = chan.trim();
+        if(chan.length) {
+            P = P.then(() => CF.delete({channel:chan}));
+        }
+        return P;
+    }, Promise.resolve())
+    .then(() => {
+        err.innerText = "";
+    })
+    .catch(exc => {
+        err.innerText = exc.message;
+    });
+}
+
+function tagChannels() {
+    const err = document.getElementById("chanerr");
+    const [name, val] = document.getElementById("chantagprop").value.split("=",2);
+    const args = {
+        owner:getOwner(),
+        channels:document.getElementById("chanlist").value
+        .split("\n")
+        .map(line => line.trim())
+        .filter(line => line.length>0)
+    };
+
+    if(name && args.channels.length>0) {
+        if(val) {
+            args.property = name;
+            args.value = val;
+        } else {
+            args.tag = name;
+        }
+    }
+
+    CF.apply(args)
+    .then(() => {
+        err.innerText = "";
+    })
+    .catch(exc => {
+        err.innerText = exc.message;
+    });
+}
+
+function untagChannels() {
+    const err = document.getElementById("chanerr");
+    const [name, val] = document.getElementById("chantagprop").value.split("=",2);
+    const args = {
+        owner:getOwner(),
+        channels:document.getElementById("chanlist").value
+        .split("\n")
+        .map(line => line.trim())
+        .filter(line => line.length>0)
+    };
+
+    if(name && args.channels.length>0) {
+        if(val) {
+            args.property = name;
+            args.value = val;
+        } else {
+            args.tag = name;
+        }
+    }
+
+    CF.remove(args)
+    .then(() => {
+        err.innerText = "";
+    })
+    .catch(exc => {
+        err.innerText = exc.message;
+    });
+}
+
+function translateList(tp, selector, list) {
+    document.querySelector(selector).replaceChildren(...list.map(ent => { // ent: {name:"", owner:""}
+        const li = document.createElement("li");
+
+        addChild(li, "span", {klass:"cf-tagprop", tip:"owner "+ent.owner}).innerText = ent.name;
+
+        li.append(" ... ");
+        const C = addChild(li, "button");
+        C.type = "button";
+        C.innerText = "Delete";
+        C.onclick = function() {
+            console.log("Delete", tp, ent.name);
+            var args = {};
+            args[tp] = ent.name;
+            CF.delete(args)
+            .finally(() => {
+                updateTagProp();
+            });
+        };
+        return li;
+    }));
+}
+
+function updateTagProp() {
+    CF.tags().then(list => translateList("tag", "#taglist", list));
+    CF.properties().then(list => translateList("property", "#proplist", list));
+}
+
+function addTagProp(tp) {
+    const err = document.getElementById("tagproperr");
+    const name = document.querySelector("#tagproptxt").value;
+    const args = {owner:getOwner()};
+    args[tp] = name;
+    console.log("Create", tp, name);
+    CF.create(args)
+    .then(() => {
+        console.log("Created", tp, name);
+        err.innerText = "";
+    })
+    .catch(exc => {
+        err.innerText = exc.message;
+    })
+    .finally(() => {
+        updateTagProp();
+    })
+}
+
+window.onload = function() {
+    updateInfo();
+    updateTagProp();
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html>
+<head>
+<meta http-equiv="Content-Type" charset="UTF-8" />
+<title>ChannelFinder Admin</title>
+<link rel="stylesheet" type="text/css" href="/cfmanage.css">
+<script src="/cf.js"></script>
+<script src="/cfmanage.js"></script>
+</head>
+<body>
+
+<div class="cf-pane">
+<h3>Service Info</h5>
+<p id="servinfo">Querying...</p>
+</div>
+
+<div class="cf-pane">
+<h3>Test query</h5>
+
+<p>
+Channel name pattern with wildcards followed by "tag" or "prop=value".
+<form method="get" action="#" onsubmit="doQuery(); return false">
+<input type="text" placeholder="eg. *" id="querytxt">
+<input type="submit" value="Execute">
+</form>
+</p>
+
+<p><ul class="cf-list" id="queryresult"></ul></p>
+</div>
+
+<div class="cf-pane">
+<p>Owner: <input type="text" min="1" placeholder="Owner name" id="ownertxt"> Used when creating channels/tags/properties</p>
+</div>
+
+<div class="cf-pane">
+<h3>Channel Managment</h5>
+
+<p>Channels list</p>
+<p>
+<textarea cols="60" rows="5" id="chanlist" placeholder="Channel names.  One per line"></textarea>
+<p>
+</p>
+<button type="button" onclick="createChannels()">Create Channels</button>
+<button type="button" onclick="deleteChannels()">Delete Channels</button>
+</p>
+<p>Apply Tag/Prop:
+<input type="text" min="1" placeholder="tag or property name=value" id="chantagprop">
+<button type="button" onclick="tagChannels()">Add</button>
+<button type="button" onclick="untagChannels()">Remove</button>
+</p>
+<p class="cf-error" id="chanerr"></p>
+</div>
+
+<div class="cf-pane">
+<h3>Tag/Property Managment</h5>
+
+<p>Tag/Prop:
+<input type="text" min="1" placeholder="tag or property name" id="tagproptxt">
+<button type="button" onclick="addTagProp('tag')">Create Tag</button>
+<button type="button" onclick="addTagProp('property')">Create Property</button>
+<p class="cf-error" id="tagproperr"></p>
+</p>
+
+<p>Tags:</p>
+<p><ul class="cf-list" id="taglist"></ul></p>
+
+<p>Properties:</p>
+<p><ul class="cf-list" id="proplist"></ul></p>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
To make it easier for new users to play around, and as a test of my understanding of the documentation, this PR adds a rudimentary management webpage to the CF service.  Allows creating/deleting tags, properties, and channels.  Assigning tags/properties to channels.  And simple querying.  This is not intended to be comprehensive, nor to be a serious substitute for other clients.  This will give someone with a newly installed server, and nothing else, an interface to explore the service.

The only java code change is to add some decorators to handle the CORS protocol mandated by modern browsers.