### PR TITLE
make a clear statement in a log regarding cleanupDB

### DIFF
--- a/src/main/java/org/phoebus/channelfinder/Application.java
+++ b/src/main/java/org/phoebus/channelfinder/Application.java
@@ -77,7 +77,9 @@ public class Application  implements ApplicationRunner {
         if(args.containsOption("cleanup")) {
             int numberOfCells = args.getOptionValues("cleanup").stream().mapToInt(Integer::valueOf).max().orElse(1);
             // This is kind of a hack, the create Db is being called to reset the channels and then deleting them
+            logger.log(Level.INFO, "Populating the channelfinder service with demo data first, then deleting them");
             service.createDB(numberOfCells);
+            logger.log(Level.INFO, "Cleaning up the populated demo data");
             service.cleanupDB();
         }
     }


### PR DESCRIPTION
Hi Kunal,

Long time no see :) I am alive ;-)

Please check this simple pull request which states clearly in a log "we are cleaning DB". 
Since I looked at the log to see how the system works. I cannot see easily the difference between `demo-data=1` and `cleanup=1`.

Any of your preference log messages are welcome.

Thanks,
@jeonghanlee 