### PR TITLE
LDAP cleanup

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,11 +8,7 @@
 
 name: Java CI with Maven
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Note that `cf.ldif` contains **default credentials** and should only be used dur
 To check that the server is running correctly.
 
 ```
-$ curl http://localhost:8080/ChannelFinder
+$ curl --fail-with-body http://localhost:8080/ChannelFinder
 {
   "name" : "ChannelFinder Service",
   "version" : "4.7.0",
@@ -91,15 +91,15 @@ $ curl http://localhost:8080/ChannelFinder
     "version" : "8.2.0"
   }
 }
-$ curl http://localhost:8080/ChannelFinder/resources/tags
+$ curl --fail-with-body http://localhost:8080/ChannelFinder/resources/tags
 []
-$ curl --basic -u admin:1234 -H 'Content-Type: application/json' \
+$ curl --basic -u admin:1234 --fail-with-body -H 'Content-Type: application/json' \
   -X PUT -d '{"name":"foo", "owner":"admin"}' \
   http://localhost:8080/ChannelFinder/resources/tags/foo
 ...
-$ curl http://localhost:8080/ChannelFinder/resources/tags
+$ curl --fail-with-body http://localhost:8080/ChannelFinder/resources/tags
 [{"name":"foo","owner":"admin","channels":[]}]
-$ curl --basic -u admin:1234 -X DELETE \
+$ curl --basic -u admin:1234 --fail-with-body -X DELETE \
   http://localhost:8080/ChannelFinder/resources/tags/foo
 ```
 

--- a/src/main/java/org/phoebus/channelfinder/WebSecurityConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/WebSecurityConfig.java
@@ -38,8 +38,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     boolean ldap_enabled;
     @Value("${ldap.urls:ldaps://localhost:389/}")
     String ldap_url;
-    @Value("${ldap.base.dn}")
-    String ldap_base_dn;
     @Value("${ldap.user.dn.pattern}")
     String ldap_user_dn_pattern;
     @Value("${ldap.groups.search.base}")
@@ -54,8 +52,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     boolean embedded_ldap_enabled;
     @Value("${embedded_ldap.urls:ldaps://localhost:389/}")
     String embedded_ldap_url;
-    @Value("${embedded_ldap.base.dn}")
-    String embedded_ldap_base_dn;
     @Value("${embedded_ldap.user.dn.pattern}")
     String embedded_ldap_user_dn_pattern;
     @Value("${embedded_ldap.groups.search.base}")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,17 +20,15 @@ spring.http.log-request-details=true
 ldap.enabled = false
 #ldap.urls = ldaps://ldap.cs.nsls2.local/dc=nsls2,dc=bnl,dc=gov
 ldap.urls = ldaps://controlns02.nsls2.bnl.gov/dc=nsls2,dc=bnl,dc=gov
-ldap.base.dn = dc=nsls2,dc=bnl,dc=gov
-ldap.user.dn.pattern = uid={0},ou=People
-ldap.groups.search.base = ou=Group
+ldap.user.dn.pattern = uid={0},ou=People,dc=nsls2,dc=bnl,dc=gov
+ldap.groups.search.base = ou=Group,dc=nsls2,dc=bnl,dc=gov
 ldap.groups.search.pattern = (memberUid= {1})
 
 ############## LDAP - Embedded ##############
 embedded_ldap.enabled = false
 embedded_ldap.urls = ldap://localhost:8389/dc=cf,dc=local
-embedded_ldap.base.dn = dc=cf,dc=local
-embedded_ldap.user.dn.pattern = uid={0},ou=People
-embedded_ldap.groups.search.base = ou=Group
+embedded_ldap.user.dn.pattern = uid={0},ou=People,dc=cf,dc=local
+embedded_ldap.groups.search.base = ou=Group,dc=cf,dc=local
 embedded_ldap.groups.search.pattern = (memberUid= {1})
 spring.ldap.embedded.ldif=classpath:cf.ldif
 spring.ldap.embedded.base-dn=dc=cf,dc=local


### PR DESCRIPTION
A couple of changes to help with my sanity while trying (and eventually succeeding) to get CF working with an external LDAP server.

While the examples make it look like they are appended to make full DNs.  However, it turns out that the `ldap.base.dn` and `embedded_ldap.base.dn` properties are not actually used.  I only figured this out after also figuring out how to turn on logging for authentication (`logging.level.org.springframework.security=DEBUG`).  Since they are not (any may never have been) used, it seems easier to simply remove them and fix the examples.

Secondly, curl with `--fail-with-body` gives a clear error (eg. `curl: (22) The requested URL returned error: 401`) when it would otherwise `exit(0)` with no obvious indication that an operation failed.

Finally, please allow github actions builds for all branch names.