### PR TITLE
Integrationtest documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ In this way, http requests (GET) and curl commands (POST, PUT, DELETE) are run t
 
 There are tests for properties, tags and channels separately and in combination.
 
+Integration tests can be run in IDE and via Maven.
+
+```
+mvn failsafe:integration-test
+```
+
+See [How to run Integration test with Docker](src/test/resources/INTEGRATIONTEST_DOCKER_RUN.md).
+
 #### ChannelFinder data managment
 
 The [cf-manager](https://github.com/ChannelFinder/cf-manager) project provides tools to perform operations on large queries ( potentially the entire directory ).

--- a/README.md
+++ b/README.md
@@ -129,33 +129,12 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--cleanup=1"
 
 #### Integration tests with Docker containers
 
-Purpose is to have integration tests for ChannelFinder API.
+Purpose is to have integration tests for ChannelFinder API with Docker.
 
 See `src/test/java` and package
 * `org.phoebus.channelfinder.docker`
 
-Integration tests are implemented in test class annotated with `@Testcontainers`. Test class starts a docker container for the application (ChannelFinder service) and another docker container for elastic (Elasticsearch) through `docker-compose-integrationtest.yml` after which JUnit tests are run.
-
-```
-    @Container
-    public static final DockerComposeContainer<?> ENVIRONMENT =
-        new DockerComposeContainer<>(new File("docker-compose-integrationtest.yml"))
-            .waitingFor(ITUtil.CHANNELFINDER, Wait.forLogMessage(".*Started Application.*", 1));
-
-    @Test
-    void channelfinderUp() {
-        try {
-            String address = ITUtil.HTTP_IP_PORT_CHANNELFINDER;
-            int responseCode = ITUtil.doGet(address);
-
-            assertEquals(HttpURLConnection.HTTP_OK, responseCode);
-        } catch (IOException e) {
-            fail();
-        }
-    }
-```
-
-In this way, http requests (GET) and curl commands (POST, PUT, DELETE) are run towards the application to test behavior (read, list, query, create, update, remove) and replies are received and checked if content is as expected.
+Integration tests start docker containers for ChannelFinder and Elasticsearch and run http requests (GET) and curl commands (POST, PUT, DELETE) towards the application to test behavior (read, list, query, create, update, remove) and replies are received and checked if content is as expected.
 
 There are tests for properties, tags and channels separately and in combination.
 
@@ -165,7 +144,9 @@ Integration tests can be run in IDE and via Maven.
 mvn failsafe:integration-test
 ```
 
-See [How to run Integration test with Docker](src/test/resources/INTEGRATIONTEST_DOCKER_RUN.md).
+See
+* [How to run Integration test with Docker](src/test/resources/INTEGRATIONTEST_DOCKER_RUN.md)
+* [Tutorial for Integration test with Docker](src/test/resources/INTEGRATIONTEST_DOCKER_TUTORIAL.md)
 
 #### ChannelFinder data managment
 

--- a/docker-compose-integrationtest.yml
+++ b/docker-compose-integrationtest.yml
@@ -49,8 +49,8 @@ services:
     networks:
       - channelfinder-net
     ports:
-      - 9200:9200
-      - 9300:9300
+      - 9201:9200
+      - 9301:9300
     environment:
       cluster.name: channelfinder
       bootstrap.memory_lock: "true"
@@ -67,3 +67,12 @@ volumes:
 networks:
   channelfinder-net:
     driver: bridge
+
+
+# ------------------------------------------------------------------------------
+# Note
+# ------------------------------------------------------------------------------
+# elasticsearch port numbers
+#     can be exposed differently externally to avoid interference with any running instance
+#     to be reflected in docker integration tests
+# ------------------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,16 @@
 					</archive>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.1.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.1.2</version>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderChannelsIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderChannelsIT.java
@@ -39,17 +39,16 @@ import org.phoebus.channelfinder.entity.Channel;
 import org.phoebus.channelfinder.docker.ITUtil.AuthorizationChoice;
 
 /**
- * Integration tests for ChannelFinder and Elasticsearch that make use of existing dockerization
- * with docker-compose.yml / Dockerfile.
- *
- * <p>
- * Focus of this class is to have ChannelFinder and Elasticsearch up and running together with usage of
+ * Integration tests for ChannelFinder and Elasticsearch with focus on usage of 
  * {@link org.phoebus.channelfinder.CFResourceDescriptors#CHANNEL_RESOURCE_URI}.
+ * Existing dockerization is used with <tt>docker-compose-integrationtest.yml</tt> and <tt>Dockerfile.integrationtest</tt>.
  *
  * @author Lars Johansson
  *
  * @see org.phoebus.channelfinder.ChannelManager
  * @see org.phoebus.channelfinder.docker.ITTestFixture
+ * @see org.phoebus.channelfinder.docker.ITUtil
+ * @see org.phoebus.channelfinder.docker.ITUtilChannels
  */
 @Testcontainers
 public class ChannelFinderChannelsIT {

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderChannelsIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderChannelsIT.java
@@ -60,7 +60,7 @@ public class ChannelFinderChannelsIT {
     //         requires
     //             elastic indices for ChannelFinder, ensured at start-up
     //             environment
-    //                 default ports, 8080 for ChannelFinder, 9200 for Elasticsearch
+    //                 default ports, can be exposed differently externally to avoid interference with any running instance
     //                 demo_auth enabled
     //         docker containers shared for tests
     //             each test to leave ChannelFinder, Elasticsearch in clean state - not disturb other tests

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderIT.java
@@ -49,7 +49,7 @@ class ChannelFinderIT {
     //         requires
     //             elastic indices for ChannelFinder, ensured at start-up
     //             environment
-    //                 default ports, 8080 for ChannelFinder, 9200 for Elasticsearch
+    //                 default ports, can be exposed differently externally to avoid interference with any running instance
     //                 demo_auth enabled
     //         docker containers shared for tests
     //             each test to leave ChannelFinder, Elasticsearch in clean state - not disturb other tests

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderIT.java
@@ -32,13 +32,12 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * Integration tests for ChannelFinder and Elasticsearch that make use of existing dockerization
- * with docker-compose-integrationtest.yml / Dockerfile.integrationtest.
- *
- * <p>
- * Focus of this class is to have ChannelFinder and Elasticsearch up and running.
+ * Integration tests for ChannelFinder and Elasticsearch with focus on endpoints being available.
+ * Existing dockerization is used with <tt>docker-compose-integrationtest.yml</tt> and <tt>Dockerfile.integrationtest</tt>.
  *
  * @author Lars Johansson
+ *
+ * @see ITUtil
  */
 @Testcontainers
 class ChannelFinderIT {

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderPropertiesIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderPropertiesIT.java
@@ -40,16 +40,15 @@ import org.junit.jupiter.api.Test;
 import org.phoebus.channelfinder.docker.ITUtil.AuthorizationChoice;
 
 /**
- * Integration tests for ChannelFinder and Elasticsearch that make use of existing dockerization
- * with docker-compose.yml / Dockerfile.
- *
- * <p>
- * Focus of this class is to have ChannelFinder and Elasticsearch up and running together with usage of
+ * Integration tests for ChannelFinder and Elasticsearch with focus on usage of 
  * {@link org.phoebus.channelfinder.CFResourceDescriptors#PROPERTY_RESOURCE_URI}.
+ * Existing dockerization is used with <tt>docker-compose-integrationtest.yml</tt> and <tt>Dockerfile.integrationtest</tt>.
  *
  * @author Lars Johansson
  *
  * @see org.phoebus.channelfinder.PropertyManager
+ * @see org.phoebus.channelfinder.docker.ITUtil
+ * @see org.phoebus.channelfinder.docker.ITUtilProperties
  */
 @Testcontainers
 class ChannelFinderPropertiesIT {

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderPropertiesIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderPropertiesIT.java
@@ -60,7 +60,7 @@ class ChannelFinderPropertiesIT {
     //         requires
     //             elastic indices for ChannelFinder, ensured at start-up
     //             environment
-    //                 default ports, 8080 for ChannelFinder, 9200 for Elasticsearch
+    //                 default ports, can be exposed differently externally to avoid interference with any running instance
     //                 demo_auth enabled
     //         docker containers shared for tests
     //             each test to leave ChannelFinder, Elasticsearch in clean state - not disturb other tests

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderScrollIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderScrollIT.java
@@ -34,16 +34,15 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * Integration tests for ChannelFinder and Elasticsearch that make use of existing dockerization
- * with docker-compose.yml / Dockerfile.
- *
- * <p>
- * Focus of this class is to have ChannelFinder and Elasticsearch up and running together with usage of
+ * Integration tests for ChannelFinder and Elasticsearch with focus on usage of 
  * {@link org.phoebus.channelfinder.CFResourceDescriptors#SCROLL_RESOURCE_URI}.
+ * Existing dockerization is used with <tt>docker-compose-integrationtest.yml</tt> and <tt>Dockerfile.integrationtest</tt>.
  *
  * @author Lars Johansson
  *
  * @see org.phoebus.channelfinder.ChannelScroll
+ * @see org.phoebus.channelfinder.docker.ITUtil
+ * @see org.phoebus.channelfinder.docker.ITUtilScroll
  */
 @Testcontainers
 class ChannelFinderScrollIT {

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderScrollIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderScrollIT.java
@@ -54,7 +54,7 @@ class ChannelFinderScrollIT {
     //         requires
     //             elastic indices for ChannelFinder, ensured at start-up
     //             environment
-    //                 default ports, 8080 for ChannelFinder, 9200 for Elasticsearch
+    //                 default ports, can be exposed differently externally to avoid interference with any running instance
     //                 demo_auth enabled
     //         docker containers shared for tests
     //             each test to leave ChannelFinder, Elasticsearch in clean state - not disturb other tests

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderTagsIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderTagsIT.java
@@ -60,7 +60,7 @@ class ChannelFinderTagsIT {
     //         requires
     //             elastic indices for ChannelFinder, ensured at start-up
     //             environment
-    //                 default ports, 8080 for ChannelFinder, 9200 for Elasticsearch
+    //                 default ports, can be exposed differently externally to avoid interference with any running instance
     //                 demo_auth enabled
     //         docker containers shared for tests
     //             each test to leave ChannelFinder, Elasticsearch in clean state - not disturb other tests

--- a/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderTagsIT.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ChannelFinderTagsIT.java
@@ -40,16 +40,15 @@ import org.junit.jupiter.api.Test;
 import org.phoebus.channelfinder.docker.ITUtil.AuthorizationChoice;
 
 /**
- * Integration tests for ChannelFinder and Elasticsearch that make use of existing dockerization
- * with docker-compose.yml / Dockerfile.
- *
- * <p>
- * Focus of this class is to have ChannelFinder and Elasticsearch up and running together with usage of
+ * Integration tests for ChannelFinder and Elasticsearch with focus on usage of 
  * {@link org.phoebus.channelfinder.CFResourceDescriptors#TAG_RESOURCE_URI}.
+ * Existing dockerization is used with <tt>docker-compose-integrationtest.yml</tt> and <tt>Dockerfile.integrationtest</tt>.
  *
  * @author Lars Johansson
  *
  * @see org.phoebus.channelfinder.TagManager
+ * @see org.phoebus.channelfinder.docker.ITUtil
+ * @see org.phoebus.channelfinder.docker.ITUtilTags
  */
 @Testcontainers
 class ChannelFinderTagsIT {

--- a/src/test/java/org/phoebus/channelfinder/docker/ITUtil.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ITUtil.java
@@ -46,8 +46,11 @@ public class ITUtil {
     static final String HTTP          = "http://";
     static final String HEADER_JSON   = "'Content-Type: application/json'";
 
+    // port numbers
+    //     can be exposed differently externally to avoid interference with any running instance
+
     static final String IP_PORT_CHANNELFINDER = "127.0.0.1:8080/ChannelFinder";
-    static final String IP_PORT_ELASTICSEARCH = "127.0.0.1:9200";
+    static final String IP_PORT_ELASTICSEARCH = "127.0.0.1:9201";
 
     static final String RESOURCES_CHANNELS = "/resources/channels";
     static final String RESOURCES_PROPERTIES = "/resources/properties";

--- a/src/test/java/org/phoebus/channelfinder/docker/ITUtil.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ITUtil.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
 
 /**
- * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch.
+ * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch with focus on support common behavior for tests.
  *
  * @author Lars Johansson
  */

--- a/src/test/java/org/phoebus/channelfinder/docker/ITUtilChannels.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ITUtilChannels.java
@@ -36,9 +36,11 @@ import org.phoebus.channelfinder.docker.ITUtil.EndpointChoice;
 import org.phoebus.channelfinder.docker.ITUtil.MethodChoice;
 
 /**
- * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch.
+ * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch with focus on support test of behavior for channel endpoints.
  *
  * @author Lars Johansson
+ *
+ * @see org.phoebus.channelfinder.docker.ITUtil
  */
 public class ITUtilChannels {
 

--- a/src/test/java/org/phoebus/channelfinder/docker/ITUtilProperties.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ITUtilProperties.java
@@ -36,9 +36,11 @@ import org.phoebus.channelfinder.docker.ITUtil.EndpointChoice;
 import org.phoebus.channelfinder.docker.ITUtil.MethodChoice;
 
 /**
- * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch.
+ * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch with focus on support test of behavior for property endpoints.
  *
  * @author Lars Johansson
+ *
+ * @see org.phoebus.channelfinder.docker.ITUtil
  */
 public class ITUtilProperties {
 

--- a/src/test/java/org/phoebus/channelfinder/docker/ITUtilScroll.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ITUtilScroll.java
@@ -30,9 +30,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.phoebus.channelfinder.entity.Scroll;
 
 /**
- * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch.
+ * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch with focus on support test of behavior for scroll endpoints.
  *
  * @author Lars Johansson
+ *
+ * @see org.phoebus.channelfinder.docker.ITUtil
  */
 public class ITUtilScroll {
 

--- a/src/test/java/org/phoebus/channelfinder/docker/ITUtilTags.java
+++ b/src/test/java/org/phoebus/channelfinder/docker/ITUtilTags.java
@@ -36,9 +36,11 @@ import org.phoebus.channelfinder.docker.ITUtil.EndpointChoice;
 import org.phoebus.channelfinder.docker.ITUtil.MethodChoice;
 
 /**
- * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch.
+ * Utility class to help (Docker) integration tests for ChannelFinder and Elasticsearch with focus on support test of behavior for tag endpoints.
  *
  * @author Lars Johansson
+ *
+ * @see org.phoebus.channelfinder.docker.ITUtil
  */
 public class ITUtilTags {
 

--- a/src/test/resources/INTEGRATIONTEST_DOCKER_RUN.md
+++ b/src/test/resources/INTEGRATIONTEST_DOCKER_RUN.md
@@ -1,0 +1,54 @@
+### Prerequisites
+
+##### Tools
+
+* Docker - engine 18.06.0+ or later, compose 1.29.2 or later, compose file version 3.7 to be supported
+
+##### Build ChannelFinder service
+
+```
+mvn clean install
+```
+
+### Run tests
+
+##### IDE
+
+All or individual integration tests (including methods) can be run in IDE as JUnit tests.
+
+##### Maven
+
+All integration tests can be run via Maven.
+
+```
+mvn failsafe:integration-test
+```
+
+Individual integration tests (classes) can also be run via Maven.
+
+```
+mvn test -Dtest=org.phoebus.channelfinder.docker.ChannelFinderChannelsIT
+mvn test -Dtest=org.phoebus.channelfinder.docker.ChannelFinderIT
+mvn test -Dtest=org.phoebus.channelfinder.docker.ChannelFinderPropertiesIT
+mvn test -Dtest=org.phoebus.channelfinder.docker.ChannelFinderScrollIT
+mvn test -Dtest=org.phoebus.channelfinder.docker.ChannelFinderTagsIT
+```
+
+### Note
+
+##### Build
+
+* (Re) Build after change in `src/main/java` in order for change to be tested
+* `Dockerfile.integrationtest` relies on built code and not on Maven central
+
+##### Configuration
+
+* Configuration in folder `src/test/java` and package `org.phoebus.channelfinder.docker`, e.g. urls and port numbers, is coupled to files `Dockerfile.integrationtest` and `docker-compose-integrationtest.yml` (beside `src/main/resources/application.properties`)
+
+##### Debug
+
+* Docker containers can be inspected when debugging integration tests
+
+##### Performance
+
+* It may take a minute to run a test. This includes time to set up the test environment, perform the test and tear down the test environment. Setting up the test environment takes most of that time.

--- a/src/test/resources/INTEGRATIONTEST_DOCKER_TUTORIAL.md
+++ b/src/test/resources/INTEGRATIONTEST_DOCKER_TUTORIAL.md
@@ -1,0 +1,360 @@
+### About
+
+Describe ability to develop and run integration tests for ChannelFinder API with Docker.
+
+In other words, how to use `src/test/java` to test `src/main/java` with integration tests using Docker.
+
+##### Background
+
+ChannelFinder with Elasticsearch together with the environment in which the applications run, is complex and usually heavily relied on by other applications and environments. Outside interface is to ChannelFinder but ChannelFinder and Elasticsearch go together. Therefore, there is need to test ChannelFinder and Elasticsearch together.
+
+It is possible to test ChannelFinder API by running ChannelFinder and Elasticsearch applications together as Docker containers and executing a series of requests and commands to test their behavior. This tutorial will show how it works and give examples.
+
+##### Content
+
+* [Prerequisites](#prerequisites)
+* [Examples](#examples)
+* [How it works - big picture](#how-it-works-big-picture)
+* [How it works - in detail](#how-it-works-in-detail)
+* [How to run](#how-to-run)
+* [Reference](#reference)
+
+### Prerequisites
+
+##### Tools
+
+* Docker - engine 18.06.0+ or later, compose 1.29.2 or later, compose file version 3.7 to be supported
+
+##### Dependencies
+
+* JUnit 5
+* Testcontainers
+
+##### Files
+
+* folder `src/test/java` and package `org.phoebus.channelfinder.docker`
+* [docker-compose-integrationtest.yml](docker-compose-integrationtest.yml)
+* [Dockerfile.integrationtest](Dockerfile.integrationtest)
+
+### Examples
+
+##### Simple
+
+[ChannelFinderIT.java](src/test/java/org/phoebus/channelfinder/docker/ChannelFinderIT.java)
+
+```
+@Test 
+void channelfinderUp()
+```
+
+Purpose
+* verify that ChannelFinder is up and running
+
+How
+* Http request (GET) is run towards ChannelFinder base url and response code is verified to be 200
+
+##### Medium
+
+[ChannelFinderPropertiesIT.java](src/test/java/org/phoebus/channelfinder/docker/ChannelFinderPropertiesIT.java)
+
+```
+@Test 
+void handleProperty()
+```
+
+Purpose
+* verify behavior for single property that include commands - list, create property, list, retrieve, delete (unauthorized), delete, list
+
+How
+* a series of Http requests (GET) and curl commands (POST, PUT, DELETE) are run towards the application to test behavior
+
+##### Complex
+
+[ChannelFinderChannelsIT.java](src/test/java/org/phoebus/channelfinder/docker/ChannelFinderChannelsIT.java)
+
+```
+@Test 
+void handleChannels3QueryByPattern()
+```
+
+Purpose
+* set up test fixture - properties, tags, channels, channels with properties & tags
+* query by pattern - search for a list of channels based on their name, tags, and/or properties
+* tear down test fixture - reverse to set up
+
+How
+* a series of Http requests (GET) and curl commands (POST, PUT, DELETE) are run towards the application to test behavior
+
+### How it works - big picture
+
+Integration tests are implemented in test class annotated with `@Testcontainers`. Test class starts a docker container for the application (ChannelFinder service) and another docker container for elastic (Elasticsearch) through `docker-compose-integrationtest.yml` and `Dockerfile.integrationtest` after which JUnit tests are run.
+
+```
+@Testcontainers
+class ChannelFinderIT {
+
+    @Container
+    public static final DockerComposeContainer<?> ENVIRONMENT =
+        new DockerComposeContainer<>(new File("docker-compose-integrationtest.yml"))
+            .waitingFor(ITUtil.CHANNELFINDER, Wait.forLogMessage(".*Started Application.*", 1));
+
+    @Test
+    void channelfinderUp() {
+        try {
+            String address = ITUtil.HTTP_IP_PORT_CHANNELFINDER;
+            int responseCode = ITUtil.doGet(address);
+
+            assertEquals(HttpURLConnection.HTTP_OK, responseCode);
+        } catch (IOException e) {
+            fail();
+        }
+    }
+```
+
+Http requests (GET) and curl commands (POST, PUT, DELETE) are run towards the application to test behavior (read, list, query, create, update, remove) and replies are received and checked if content is as expected.
+
+There are tests for properties, tags and channels separately and in combination.
+
+##### Note
+
+* Docker containers (ChannelFinder, Elasticsearch) are shared for tests within test class. Order in which tests are run is not known. Therefore, each test is to leave ChannelFinder, Elasticsearch in a clean state to not disturb other tests.
+
+### How it works - in detail
+
+##### Anatomy of an integration test
+
+```
+@Testcontainers
+class ChannelFinderPropertiesIT {
+
+    static Property property_p1_owner_o1;
+
+    @Container
+    public static final DockerComposeContainer<?> ENVIRONMENT =
+        new DockerComposeContainer<>(new File("docker-compose-integrationtest.yml"))
+            .waitingFor(ITUtil.CHANNELFINDER, Wait.forLogMessage(".*Started Application.*", 1));
+
+    @BeforeAll
+    public static void setupObjects() {
+        property_p1_owner_o1 = new Property("p1", "o1", null);
+    }
+
+    @AfterAll
+    public static void tearDownObjects() {
+        property_p1_owner_o1 = null;
+    }
+
+    /**
+     * Test {@link org.phoebus.channelfinder.CFResourceDescriptors#PROPERTY_RESOURCE_URI}.
+     */
+    @Test
+    void handleProperty() {
+        // what
+        //     user with required role PropertyMod
+        //     create property
+        //     --------------------------------------------------------------------------------
+        //     list, create property, list, retrieve, delete (unauthorized), delete, list
+        //     --------------------------------------------------------------------------------
+        //     x   Retrieve a Property
+        //     x   List Properties
+        //     x   Create/Replace a Property
+        //     x   Remove Property
+
+        try {
+            ITUtilProperties.assertListProperties(0);
+
+            ITUtilProperties.assertCreateReplaceProperty(AuthorizationChoice.ADMIN, "/t1", property_p1_owner_o1);
+
+            ITUtilProperties.assertListProperties(1, property_p1_owner_o1);
+
+            ITUtilProperties.assertRetrieveProperty("/p1",                    property_p1_owner_o1);
+            ITUtilProperties.assertRetrieveProperty("/p1?withChannels=true",  property_p1_owner_o1);
+            ITUtilProperties.assertRetrieveProperty("/p1?withChannels=false", property_p1_owner_o1);
+
+            ITUtilProperties.assertRemoveProperty(AuthorizationChoice.NONE,  "/p1", HttpURLConnection.HTTP_UNAUTHORIZED);
+            ITUtilProperties.assertRemoveProperty(AuthorizationChoice.USER,  "/p1", HttpURLConnection.HTTP_UNAUTHORIZED);
+            ITUtilProperties.assertRemoveProperty(AuthorizationChoice.ADMIN, "/p1", HttpURLConnection.HTTP_OK);
+
+            ITUtilProperties.assertListProperties(0);
+        } catch (Exception e) {
+            fail();
+        }
+    }
+```
+
+##### What happens at runtime
+
+The test environment is started with through test class annotated with `@Testcontainers` and constant `ENVIRONMENT` annotated with `@Container`. Containers are started (Ryuk, ChannelFinder, Elasticsearch). Then one time setup is run (method annotated with `@BeforeAll`), after which individual tests are run (methods annotated with `@Test`) after which one time tear down is run (method annotated with `@AfterAll`). Finally tasks are done and test class is closed.
+
+Note the extensive use of test utility classes (in more detail below) in which are shared code for common tasks.
+
+* authorization
+* serialization and deserialization of properties, tags and channels
+* Http requests (GET) and curl commands (POST, PUT, DELETE) corresponding to endpoints in ChannelFinder API
+* assert response
+
+##### Examining `handleProperty`
+
+1.  A GET request is made to ChannelFinder to list all properties and ensure there are no properties available.
+2.  A PUT request is made to ChannelFinder to create the property listed by the path parameter. Request is made with ADMIN authority.
+3.  A GET request is made to ChannelFinder to list all properties and ensure there is one (given) property available.
+4.  A GET request is made to ChannelFinder to retrieve property with given name.
+5.  A GET request is made to ChannelFinder to retrieve property with given name with associated channel information.
+6.  A GET request is made to ChannelFinder to retrieve property with given name without associated channel information.
+7.  A DELETE request is made to ChannelFinder to delete property. Request is made without authority.
+8.  A DELETE request is made to ChannelFinder to delete property. Request is made with USER authority.
+9.  A DELETE request is made to ChannelFinder to delete property. Request is made with ADMIN authority.
+10. A GET request is made to ChannelFinder to list all properties and ensure there are no properties available.
+
+
+* 1, 3, 10 - Request corresponds to PropertyManager method
+
+```
+    @GetMapping
+    public Iterable<Property> list() {
+```
+
+* 2 - Request corresponds to PropertyManager method
+
+```
+    @PutMapping("/{propertyName}")
+    public Property create(@PathVariable("propertyName") String propertyName, @RequestBody Property property) {
+```
+
+* 4, 5, 6 - Request corresponds to PropertyManager method
+
+```
+    @GetMapping("/{propertyName}")
+    public Property read(@PathVariable("propertyName") String propertyName,
+                         @RequestParam(value = "withChannels", defaultValue = "true") boolean withChannels) {
+```
+
+* 7, 8, 9 - Request corresponds to PropertyManager method
+
+```
+    @DeleteMapping("/{propertyName}")
+    public void remove(@PathVariable("propertyName") String propertyName) {
+```
+
+##### Test classes
+
+See `src/test/java` and `org.phoebus.channelfinder.docker`.
+
+* files with suffix IT.java
+
+##### Test utilities
+
+See `src/test/java` and `org.phoebus.channelfinder.docker`.
+
+* files with prefix ITTestFixture
+* files with prefix ITUtil
+
+##### Test utilities - example
+
+With the help of test utitilies, the tests themselves may be simplified and made more clear.
+
+```
+public class ITUtilChannels {
+
+    public static Channel[] assertListChannels(int expectedEqual) {
+        return assertListChannels("", HttpURLConnection.HTTP_OK, expectedEqual, expectedEqual, CHANNELS_NULL);
+    }
+    public static Channel[] assertListChannels(int expectedEqual, Channel... expected) {
+        return assertListChannels("", HttpURLConnection.HTTP_OK, expectedEqual, expectedEqual, expected);
+    }
+    public static Channel[] assertListChannels(String queryString, Channel... expected) {
+        return assertListChannels(queryString, HttpURLConnection.HTTP_OK, -1, -1, expected);
+    }
+    public static Channel[] assertListChannels(String queryString, int expectedEqual) {
+        return assertListChannels(queryString, HttpURLConnection.HTTP_OK, expectedEqual, expectedEqual, CHANNELS_NULL);
+    }
+    public static Channel[] assertListChannels(String queryString, int responseCode, int expectedEqual) {
+        return assertListChannels(queryString, responseCode, expectedEqual, expectedEqual, CHANNELS_NULL);
+    }
+
+    /**
+     * Utility method to return the list of channels which match all given expressions, i.e. the expressions are combined in a logical AND.
+     *
+     * @param queryString query string
+     * @param responseCode response code
+     * @param expectedGreaterThanOrEqual (if non-negative number) greater than or equal to this number of items
+     * @param expectedLessThanOrEqual (if non-negative number) less than or equal to this number of items
+     * @param expected expected response channels
+     * @return number of channels
+     */
+    public static Channel[] assertListChannels(String queryString, int responseCode, int expectedGreaterThanOrEqual, int expectedLessThanOrEqual, Channel... expected) {
+        try {
+            String[] response = null;
+            Channel[] actual = null;
+
+            response = ITUtil.doGetJson(ITUtil.HTTP_IP_PORT_CHANNELFINDER_RESOURCES_CHANNELS + queryString);
+            ITUtil.assertResponseLength2Code(response, responseCode);
+            if (HttpURLConnection.HTTP_OK == responseCode) {
+                actual = mapper.readValue(response[1], Channel[].class);
+            }
+
+            // expected number of items in list
+            //     (if non-negative number)
+            //     expectedGreaterThanOrEqual <= nbr of items <= expectedLessThanOrEqual
+            if (expectedGreaterThanOrEqual >= 0) {
+                assertTrue(actual.length >= expectedGreaterThanOrEqual);
+            }
+            if (expectedLessThanOrEqual >= 0) {
+                assertTrue(actual.length <= expectedLessThanOrEqual);
+            }
+
+            // expected content
+            if (expected != null) {
+                assertEqualsChannels(actual, expected);
+            }
+
+            return actual;
+        } catch (IOException e) {
+            fail();
+        } catch (Exception e) {
+            fail();
+        }
+        return null;
+    }
+```
+
+Above methods can be used like shown below.
+
+```
+@Testcontainers
+public class ChannelFinderChannelsIT {
+
+    @Test
+    void handleChannels3QueryByPattern() {
+
+            ITUtilChannels.assertListChannels("?~name=asdf", 0);
+
+            ITUtilChannels.assertListChannels("?~name=ABC:DEF-GHI:JKL:001", ITTestFixture.channel_ghi001_properties_tags);
+
+            ITUtilChannels.assertListChannels("?~name=*001",
+                    ITTestFixture.channel_ghi001_properties_tags,
+                    ITTestFixture.channel_xyz001_properties_tags);
+
+```
+
+##### Note
+
+* (Re) Build after change in `src/main/java` is needed in order for change to be tested as `Dockerfile.integrationtest` relies on built code.
+* Configuration in folder `src/test/java` and package `org.phoebus.channelfinder.docker`, e.g. urls and port numbers, is coupled to files `Dockerfile.integrationtest` and `docker-compose-integrationtest.yml` (beside `src/main/resources/application.properties`).
+* Both positive and negative tests are important to ensure validation works as expected.
+
+### How to run
+
+See [How to run Integration test with Docker](INTEGRATIONTEST_DOCKER_RUN.md).
+
+### Reference
+
+##### ChannelFinder
+
+* [ChannelFinder - Enhanced Directory Service](https://channelfinder.readthedocs.io/en/latest/api.html)
+
+##### Testcontainers
+
+* [Testcontainers](https://testcontainers.com/)
+* Dependency up to 1.18.0. Later versions experience difficulties for tests (Ryuk container) to find/attach to other containers
+(ChannelFinder and Elasticsearch).


### PR DESCRIPTION
Retake on branch for integration test documentation ( after other commits ).

Branch is about documentation on integrationtests with Docker. It includes instructions on how to run integration tests as well as tutorial for integration tests themselves. In addition, Maven surefire and failsafe plugins have been added that allow easier running of tests from command line. There is adjustment for port number used during test to not interfere with running instance of Elasticsearch.

Welcome to have a look!
@shroffk @jacomago 