### PR TITLE
Add pause resume functionality to archiver functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,22 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId> <!-- Need for running tests on mac -->
+            <artifactId>netty-all</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <!-- read properties from the pom file and add them to the application.properties -->

--- a/src/main/java/org/phoebus/channelfinder/processors/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/AAChannelProcessor.java
@@ -1,7 +1,9 @@
 package org.phoebus.channelfinder.processors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.phoebus.channelfinder.entity.Channel;
 import org.phoebus.channelfinder.entity.Property;
@@ -9,49 +11,58 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.util.*;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
- * A post processor which uses the channel property *archive* to add pv's to the archiver appliance
- * The archive parameters are specified in the property value, they consist of 2 parts
- * the sampling method which can be scan or monitor
- * the sampling rate defined in seconds
+ * A post processor which uses the channel property *archive* to add pv's to the archiver appliance The archive
+ * parameters are specified in the property value, they consist of 2 parts the sampling method which can be scan or
+ * monitor the sampling rate defined in seconds
  * <p>
  * e.g. archive=monitor@1.0
  */
 @Configuration
-public class AAChannelProcessor implements ChannelProcessor{
+public class AAChannelProcessor implements ChannelProcessor {
 
     private static final Logger logger = Logger.getLogger(AAChannelProcessor.class.getName());
+    private static final String MGMT_RESOURCE = "/mgmt/bpl";
+    private static final String POLICY_RESOURCE = MGMT_RESOURCE + "/getPolicyList";
+    private static final String PV_STATUS_RESOURCE = MGMT_RESOURCE + "/getPVStatus";
 
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String PV_STATUS_PROPERTY_NAME = "pvStatus"; // Matches in recsync
+    private static final String PV_STATUS_INACTIVE = "Inactive";
+    public static final String PV_STATUS_ACTIVE = "Active";
+    private final WebClient client = WebClient.create();
     @Value("${aa.enabled:true}")
     private boolean aaEnabled;
-
     @Value("#{${aa.urls:{'default': 'http://localhost:17665'}}}")
     private Map<String, String> aaURLs;
-
     @Value("${aa.default_alias:default}")
     private String defaultArchiver;
-
     @Value("${aa.pva:false}")
     private boolean aaPVA;
-
     @Value("${aa.archive_property_name:archive}")
     private String archivePropertyName;
     @Value("${aa.archiver_property_name:archiver}")
     private String archiverPropertyName;
-
-    private static final String mgmtResource = "/mgmt/bpl/archivePV";
-    private static final String policyResource = "/mgmt/bpl/getPolicyList";
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-    private final WebClient client = WebClient.create();
-
+    @Value("${aa.auto_pause:pvStatus,archive}")
+    private List<String> autoPauseOptions;
 
     @Override
     public boolean enabled() {
@@ -65,61 +76,188 @@ public class AAChannelProcessor implements ChannelProcessor{
 
     @Override
     public void process(List<Channel> channels) throws JsonProcessingException {
-        Map<String, List<ArchivePV>> aaArchivePVS = new HashMap<>();
-        for (String alias: aaURLs.keySet()) {
+        if (channels.isEmpty()) {
+            return;
+        }
+        Map<String, List<ArchivePV>> aaArchivePVS = new HashMap<>(); // AA identifier, ArchivePV
+        for (String alias : aaURLs.keySet()) {
             aaArchivePVS.put(alias, new ArrayList<>());
         }
         Map<String, List<String>> policyLists = getAAsPolicies(aaURLs);
+
+        logger.log(Level.INFO, "Get channelfinder properties for aa processor.");
         channels.forEach(channel -> {
-            Optional<Property> archiverProperty = channel.getProperties().stream()
-                    .filter(xmlProperty -> archiverPropertyName.equalsIgnoreCase(xmlProperty.getName()))
-                    .findFirst();
             Optional<Property> archiveProperty = channel.getProperties().stream()
                     .filter(xmlProperty -> archivePropertyName.equalsIgnoreCase(xmlProperty.getName()))
                     .findFirst();
-            if(archiveProperty.isPresent()) {
-                String archiverAlias = archiverProperty.isPresent() ? aaURLs.get(archiverProperty.get().getValue()): defaultArchiver;
-                ArchivePV newArchiverPV = getArchivePV(policyLists.get(archiverAlias), channel, archiveProperty.get().getValue());
+            if (archiveProperty.isPresent()) {
+                String pvStatus = channel.getProperties().stream()
+                        .filter(xmlProperty -> PV_STATUS_PROPERTY_NAME.equalsIgnoreCase(xmlProperty.getName()))
+                        .findFirst()
+                        .map(Property::getValue)
+                        .orElse(PV_STATUS_INACTIVE);
+                String archiverAlias = channel.getProperties().stream()
+                        .filter(xmlProperty -> archiverPropertyName.equalsIgnoreCase(xmlProperty.getName()))
+                        .findFirst()
+                        .map(Property::getValue)
+                        .orElse(defaultArchiver);
+                ArchivePV newArchiverPV = createArchivePV(
+                        policyLists.get(archiverAlias),
+                        channel,
+                        archiveProperty.get().getValue(),
+                        autoPauseOptions.contains(PV_STATUS_PROPERTY_NAME) ? pvStatus : PV_STATUS_ACTIVE);
                 aaArchivePVS.get(archiverAlias).add(newArchiverPV);
+            } else if (autoPauseOptions.contains(archivePropertyName)) {
+                aaURLs.keySet().forEach(archiverAlias -> aaArchivePVS
+                        .get(archiverAlias)
+                        .add(createArchivePV(List.of(), channel, "", PV_STATUS_INACTIVE)));
             }
         });
 
         for (Map.Entry<String, List<ArchivePV>> e : aaArchivePVS.entrySet()) {
-            configureAA(e.getValue(), aaURLs.get(e.getKey()));
+            String archiverURL = aaURLs.get(e.getKey());
+            Map<String, ArchivePV> archivePVSList =
+                    e.getValue().stream().collect(Collectors.toMap(archivePV -> archivePV.pv, archivePV -> archivePV));
+            Map<ArchiveAction, List<ArchivePV>> archiveActionArchivePVMap =
+                    getArchiveActions(archivePVSList, archiverURL);
+            configureAA(archiveActionArchivePVMap, archiverURL);
         }
     }
 
-    private ArchivePV getArchivePV(List<String> policyList, Channel channel, String archiveProperty) {
-        ArchivePV newArchiverPV = new ArchivePV();
-        if(aaPVA && !channel.getName().contains("://")) {
-            newArchiverPV.setPv("pva://" + channel.getName());
+    private ArchiveAction pickArchiveAction(String archiveStatus, String pvStatus) {
+        if (archiveStatus.equals("Being archived") && (pvStatus.equals(PV_STATUS_INACTIVE))) {
+            return ArchiveAction.PAUSE;
+        } else if (archiveStatus.equals("Paused") && (pvStatus.equals(PV_STATUS_ACTIVE))) {
+            return ArchiveAction.RESUME;
+        } else if (!archiveStatus.equals("Being archived")
+                && !archiveStatus.equals("Paused")
+                && pvStatus.equals(PV_STATUS_ACTIVE)) { // If archive status anything else
+            return ArchiveAction.ARCHIVE;
         }
-        else {
+
+        return ArchiveAction.NONE;
+    }
+
+    private Map<ArchiveAction, List<ArchivePV>> getArchiveActions(
+            Map<String, ArchivePV> archivePVS, String archiverURL) {
+        logger.log(Level.INFO, () -> String.format("Get archiver status in archiver %s", archiverURL));
+
+        Map<ArchiveAction, List<ArchivePV>> result = new EnumMap<>(ArchiveAction.class);
+        Arrays.stream(ArchiveAction.values()).forEach(archiveAction -> result.put(archiveAction, new ArrayList<>()));
+        // Don't request to archive an empty list.
+        if (archivePVS.isEmpty()) {
+            return result;
+        }
+
+        try {
+            URI pvStatusURI = UriComponentsBuilder.fromUri(URI.create(archiverURL + PV_STATUS_RESOURCE))
+                    .queryParam("pv", archivePVS.keySet())
+                    .build()
+                    .toUri();
+
+            String response = client.post()
+                    .uri(pvStatusURI)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .timeout(Duration.of(10, ChronoUnit.SECONDS))
+                    .block();
+
+            // Structure of response is
+            // [{"pvName":"PV:1", "status":"Paused", ... }, {"pvName": "PV:2"}, {"status": "Being archived"}, ...}, ...
+            // ]
+
+            objectMapper
+                    .readValue(response, new TypeReference<List<Map<String, String>>>() {})
+                    .forEach(archivePVStatusJsonMap -> {
+                        String archiveStatus = archivePVStatusJsonMap.get("status");
+                        String pvName = archivePVStatusJsonMap.get("pvName");
+                        String pvStatus = archivePVS.get(pvName).getPvStatus();
+                        ArchiveAction action = pickArchiveAction(archiveStatus, pvStatus);
+                        result.get(action).add(archivePVS.get(pvName));
+                    });
+            return result;
+
+        } catch (JsonProcessingException e) {
+            // problem collecting policies from AA, so warn and return empty list
+            logger.log(Level.WARNING, "Could not get AA pv Status list: " + e.getMessage());
+            return result;
+        }
+    }
+
+    private ArchivePV createArchivePV(
+            List<String> policyList, Channel channel, String archiveProperty, String pvStaus) {
+        ArchivePV newArchiverPV = new ArchivePV();
+        if (aaPVA && !channel.getName().contains("://")) {
+            newArchiverPV.setPv("pva://" + channel.getName());
+        } else {
             newArchiverPV.setPv(channel.getName());
         }
         newArchiverPV.setSamplingParameters(archiveProperty, policyList);
+        newArchiverPV.setPvStatus(pvStaus);
         return newArchiverPV;
     }
 
+    private void configureAA(Map<ArchiveAction, List<ArchivePV>> archivePVS, String aaURL)
+            throws JsonProcessingException {
+        logger.log(Level.INFO, () -> String.format("Configure PVs %s in %s", archivePVS.toString(), aaURL));
 
-    private void configureAA(List<ArchivePV> archivePVS, String aaURL) throws JsonProcessingException {
         // Don't request to archive an empty list.
         if (archivePVS.isEmpty()) {
             return;
         }
+        if (!archivePVS.get(ArchiveAction.ARCHIVE).isEmpty()) {
+            logger.log(
+                    Level.INFO,
+                    () -> "Submitting to be archived "
+                            + archivePVS.get(ArchiveAction.ARCHIVE).size() + " pvs");
+            submitAction(
+                    objectMapper.writeValueAsString(archivePVS.get(ArchiveAction.ARCHIVE)),
+                    ArchiveAction.ARCHIVE.endpoint,
+                    aaURL);
+        }
+        if (!archivePVS.get(ArchiveAction.PAUSE).isEmpty()) {
+            logger.log(
+                    Level.INFO,
+                    () -> "Submitting to be paused "
+                            + archivePVS.get(ArchiveAction.PAUSE).size() + " pvs");
+            submitAction(
+                    objectMapper.writeValueAsString(archivePVS.get(ArchiveAction.PAUSE).stream()
+                            .map(ArchivePV::getPv)
+                            .collect(Collectors.toList())),
+                    ArchiveAction.PAUSE.endpoint,
+                    aaURL);
+        }
+        if (!archivePVS.get(ArchiveAction.RESUME).isEmpty()) {
+            logger.log(
+                    Level.INFO,
+                    () -> "Submitting to be resumed "
+                            + archivePVS.get(ArchiveAction.RESUME).size() + " pvs");
+            submitAction(
+                    objectMapper.writeValueAsString(archivePVS.get(ArchiveAction.RESUME).stream()
+                            .map(ArchivePV::getPv)
+                            .collect(Collectors.toList())),
+                    ArchiveAction.RESUME.endpoint,
+                    aaURL);
+        }
+    }
+
+    private void submitAction(String values, String endpoint, String aaURL) {
+
         String response = client.post()
-                .uri(URI.create(aaURL + mgmtResource))
+                .uri(URI.create(aaURL + MGMT_RESOURCE + endpoint))
                 .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(objectMapper.writeValueAsString(archivePVS))
+                .bodyValue(values)
                 .retrieve()
                 .bodyToMono(String.class)
+                .timeout(Duration.of(10, ChronoUnit.SECONDS))
                 .block();
-        logger.log(Level.INFO, response);
+        logger.log(Level.FINE, () -> response);
     }
 
     private Map<String, List<String>> getAAsPolicies(Map<String, String> aaURLs) {
         Map<String, List<String>> result = new HashMap<>();
-        for (String aaAlias: aaURLs.keySet()) {
+        for (String aaAlias : aaURLs.keySet()) {
             result.put(aaAlias, getAAPolicies(aaURLs.get(aaAlias)));
         }
         return result;
@@ -128,18 +266,34 @@ public class AAChannelProcessor implements ChannelProcessor{
     private List<String> getAAPolicies(String aaURL) {
         try {
             String response = client.get()
-                    .uri(URI.create(aaURL + policyResource))
+                    .uri(URI.create(aaURL + POLICY_RESOURCE))
                     .retrieve()
                     .bodyToMono(String.class)
+                    .timeout(Duration.of(10, ChronoUnit.SECONDS))
                     .block();
             Map<String, String> policyMap = objectMapper.readValue(response, Map.class);
-            List<String> policies = new ArrayList<>(policyMap.keySet());
-            return policies;
-        }
-        catch (Exception e) {
+            return new ArrayList<>(policyMap.keySet());
+        } catch (Exception e) {
             // problem collecting policies from AA, so warn and return empty list
             logger.log(Level.WARNING, "Could not get AA policies list: " + e.getMessage());
             return List.of();
+        }
+    }
+
+    enum ArchiveAction {
+        ARCHIVE("/archivePV"),
+        PAUSE("/pauseArchivingPV"),
+        RESUME("/resumeArchivingPV"),
+        NONE("");
+
+        private final String endpoint;
+
+        ArchiveAction(final String endpoint) {
+            this.endpoint = endpoint;
+        }
+
+        public String getEndpoint() {
+            return this.endpoint;
         }
     }
 
@@ -149,6 +303,18 @@ public class AAChannelProcessor implements ChannelProcessor{
         private String samplingMethod;
         private String samplingPeriod;
         private String policy;
+        @JsonIgnore
+        private String pvStatus;
+
+        @Override
+        public String toString() {
+            return "ArchivePV{" + "pv='"
+                    + pv + '\'' + ", samplingMethod='"
+                    + samplingMethod + '\'' + ", samplingPeriod='"
+                    + samplingPeriod + '\'' + ", policy='"
+                    + policy + '\'' + ", pvStatus='"
+                    + pvStatus + '\'' + '}';
+        }
 
         public String getPv() {
             return pv;
@@ -160,18 +326,19 @@ public class AAChannelProcessor implements ChannelProcessor{
 
         /**
          * process the archive property value string to configure the sampling method and rate
+         *
          * @param parameters string expected in the form monitor@1.0
          */
         public void setSamplingParameters(String parameters, List<String> policyList) {
-            if(parameters.equalsIgnoreCase("default")){
+            if (parameters.equalsIgnoreCase("default")) {
                 return;
             }
-            if(policyList.contains(parameters)) {
+            if (policyList.contains(parameters)) {
                 setPolicy(parameters);
                 return;
             }
             String[] p = parameters.split("@");
-            if(p.length == 2) {
+            if (p.length == 2) {
                 switch (p[0].toUpperCase()) {
                     case "MONITOR":
                         setSamplingMethod("MONITOR");
@@ -189,14 +356,12 @@ public class AAChannelProcessor implements ChannelProcessor{
                 // catch number format errors
                 try {
                     Float.parseFloat(sp);
-                }
-                catch(NumberFormatException e) {
+                } catch (NumberFormatException e) {
                     logger.log(Level.WARNING, "Invalid sampling period" + sp);
                     setSamplingMethod(null);
                     return;
                 }
                 setSamplingPeriod(sp);
-
             }
         }
 
@@ -222,6 +387,14 @@ public class AAChannelProcessor implements ChannelProcessor{
 
         public void setPolicy(String policy) {
             this.policy = policy;
+        }
+
+        public String getPvStatus() {
+            return pvStatus;
+        }
+
+        public void setPvStatus(String pvStatus) {
+            this.pvStatus = pvStatus;
         }
     }
 }

--- a/src/main/java/org/phoebus/channelfinder/processors/ChannelProcessorService.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/ChannelProcessorService.java
@@ -22,7 +22,7 @@ public class ChannelProcessorService {
     private TaskExecutor taskExecutor;
 
     long getProcessorCount() {
-        return channelProcessors.stream().count();
+        return channelProcessors.size();
     }
 
     List<String> getProcessorsNames() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,7 @@ server.ssl.key-alias=cf
 
 security.require-ssl=true
 
-logging.level.org.springframework.web=DEBUG
+logging.level.org.springframework.web=INFO
 spring.http.log-request-details=true
 
 # Enable HTTP/2 support, if the current environment supports it

--- a/src/site/sphinx/config.rst
+++ b/src/site/sphinx/config.rst
@@ -61,3 +61,26 @@ Embedded LDAP Server
 When :ref:`conf-embedded_ldap.enabled` is **true**,
 An LDAP server is run by the channelfinder service process and is initially populated
 with entries read from the file referenced by :ref:`conf-embedded_ldap.urls`.
+
+Archiver Appliance Configuration Processor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To enable the archiver appliance configuration processor, set the property :ref:`aa.enabled` to **true**.
+
+A list of archiver appliance URLs and aliases. ::
+
+    aa.urls={'default': 'http://archiver-01.example.com:17665', 'neutron-controls': 'http://archiver-02.example.com:17665'}
+
+To set the choice of default archiver appliance, set the property :ref:`aa.default_alias` to the alias of the default archiver appliance.
+
+To pass the PV as "pva://PVNAME" to the archiver appliance, set the property :ref:`aa.pva` to **true**.
+
+The properties checked for setting a PV to be archived are ::
+
+    aa.archive_property_name=archive
+    aa.archiver_property_name=archiver
+
+
+To set the auto pause behaviour, configure the parameter :ref:`aa.auto_pause`. Set to pvStatus to pause on pvStatus=Inactive,
+and resume on pvStatus=Active. Set to archive to pause on archive_property_name not existing. Set to both to pause on pvStatus=Inactive and archive_property_name::
+
+    aa.auto_pause=pvStatus,archive

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorIT.java
@@ -1,0 +1,177 @@
+package org.phoebus.channelfinder.processors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.phoebus.channelfinder.entity.Channel;
+import org.phoebus.channelfinder.entity.Property;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WebMvcTest(AAChannelProcessor.class)
+@TestPropertySource(value = "classpath:application_test.properties")
+class AAChannelProcessorIT {
+
+    protected static Property archiveProperty = new Property("archive", "owner", "default");
+    protected static Property activeProperty = new Property("pvStatus", "owner", "Active");
+    protected static Property inactiveProperty = new Property("pvStatus", "owner", "Inactive");
+
+    @Autowired
+    AAChannelProcessor aaChannelProcessor;
+
+    MockWebServer mockArchiverAppliance;
+    ObjectMapper objectMapper;
+
+    @NotNull
+    private static Stream<Arguments> processSource() {
+        return Stream.of(
+                Arguments.of(
+                        new Channel("PVArchivedActive", "owner", List.of(archiveProperty, activeProperty), List.of()),
+                        "Being archived",
+                        "",
+                        ""),
+                Arguments.of(
+                        new Channel("PVPausedActive", "owner", List.of(archiveProperty, activeProperty), List.of()),
+                        "Paused",
+                        "resumeArchivingPV",
+                        "[\"PVPausedActive\"]"),
+                Arguments.of(
+                        new Channel("PVNoneActive", "owner", List.of(archiveProperty, activeProperty), List.of()),
+                        "Not being archived",
+                        "archivePV",
+                        "[{\"pv\":\"PVNoneActive\"}]"),
+                Arguments.of(
+                        new Channel(
+                                "PVArchivedInactive", "owner", List.of(archiveProperty, inactiveProperty), List.of()),
+                        "Being archived",
+                        "pauseArchivingPV",
+                        "[\"PVArchivedInactive\"]"),
+                Arguments.of(
+                        new Channel("PVPausedInactive", "owner", List.of(archiveProperty, inactiveProperty), List.of()),
+                        "Paused",
+                        "",
+                        ""),
+                Arguments.of(
+                        new Channel("PVNoneInactive", "owner", List.of(archiveProperty, inactiveProperty), List.of()),
+                        "Not being archived",
+                        "",
+                        ""),
+                Arguments.of(
+                        new Channel("PVArchivedNotag", "owner", List.of(), List.of()),
+                        "Being archived",
+                        "pauseArchivingPV",
+                        "[\"PVArchivedNotag\"]"));
+    }
+
+    public static void paramableAAChannelProcessorTest(
+            MockWebServer mockArchiverAppliance,
+            ObjectMapper objectMapper,
+            ChannelProcessor aaChannelProcessor,
+            Channel channel,
+            String archiveStatus,
+            String archiverEndpoint,
+            String submissionBody)
+            throws JsonProcessingException, InterruptedException {
+        // Request to policies
+        Map<String, String> policyList = Map.of("policy", "description");
+        mockArchiverAppliance.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(policyList))
+                .addHeader("Content-Type", "application/json"));
+
+        if (!archiveStatus.isEmpty()) {
+
+            // Request to archiver status
+            List<Map<String, String>> archivePVStatuses =
+                    List.of(Map.of("pvName", channel.getName(), "status", archiveStatus));
+            mockArchiverAppliance.enqueue(new MockResponse()
+                    .setBody(objectMapper.writeValueAsString(archivePVStatuses))
+                    .addHeader("Content-Type", "application/json"));
+        }
+        if (!archiverEndpoint.isEmpty()) {
+            // Request to archiver to archive
+            List<Map<String, String>> archiverResponse =
+                    List.of(Map.of("pvName", channel.getName(), "status", "Archive request submitted"));
+            mockArchiverAppliance.enqueue(new MockResponse()
+                    .setBody(objectMapper.writeValueAsString(archiverResponse))
+                    .addHeader("Content-Type", "application/json"));
+        }
+
+        aaChannelProcessor.process(List.of(channel));
+
+        int expectedRequests = 1;
+        RecordedRequest requestPolicy = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
+        assert requestPolicy != null;
+        assertEquals("/mgmt/bpl/getPolicyList", requestPolicy.getPath());
+
+        if (!archiveStatus.isEmpty()) {
+            expectedRequests += 1;
+            RecordedRequest requestStatus = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
+            assert requestStatus != null;
+            assert requestStatus.getRequestUrl() != null;
+            assertEquals("/mgmt/bpl/getPVStatus", requestStatus.getRequestUrl().encodedPath());
+        }
+
+        if (!archiverEndpoint.isEmpty()) {
+            expectedRequests += 1;
+            RecordedRequest requestAction = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
+            assert requestAction != null;
+            assertEquals("/mgmt/bpl/" + archiverEndpoint, requestAction.getPath());
+            assertEquals(submissionBody, requestAction.getBody().readUtf8());
+        }
+
+        assertEquals(mockArchiverAppliance.getRequestCount(), expectedRequests);
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockArchiverAppliance = new MockWebServer();
+        mockArchiverAppliance.start(17665);
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void teardown() throws IOException {
+        mockArchiverAppliance.shutdown();
+    }
+
+    @Test
+    void testProcessNoPVs() throws JsonProcessingException {
+        aaChannelProcessor.process(List.of());
+
+        assertEquals(mockArchiverAppliance.getRequestCount(), 0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("processSource")
+    void testProcessNotArchivedActive(
+            Channel channel, String archiveStatus, String archiverEndpoint, String submissionBody)
+            throws JsonProcessingException, InterruptedException {
+        paramableAAChannelProcessorTest(
+                mockArchiverAppliance,
+                objectMapper,
+                aaChannelProcessor,
+                channel,
+                archiveStatus,
+                archiverEndpoint,
+                submissionBody);
+    }
+}

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorNoPauseIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorNoPauseIT.java
@@ -1,0 +1,80 @@
+package org.phoebus.channelfinder.processors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.phoebus.channelfinder.entity.Channel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.archiveProperty;
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.inactiveProperty;
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.paramableAAChannelProcessorTest;
+
+@WebMvcTest(AAChannelProcessor.class)
+@TestPropertySource(locations = "classpath:application_test.properties", properties = "aa.auto_pause=none")
+class AAChannelProcessorNoPauseIT {
+
+    @Autowired
+    AAChannelProcessor aaChannelProcessor;
+
+    MockWebServer mockArchiverAppliance;
+    ObjectMapper objectMapper;
+
+    private static Stream<Arguments> processNoPauseSource() {
+
+        return Stream.of(
+                Arguments.of(
+                        new Channel(
+                                "PVArchivedInactive", "owner", List.of(archiveProperty, inactiveProperty), List.of()),
+                        "Being archived",
+                        "",
+                        ""),
+                Arguments.of(
+                        new Channel("PVArchivedNotag", "owner", List.of(), List.of()),
+                        "",
+                        "",
+                        ""));
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockArchiverAppliance = new MockWebServer();
+        mockArchiverAppliance.start(17665);
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void teardown() throws IOException {
+        mockArchiverAppliance.shutdown();
+    }
+
+    @ParameterizedTest
+    @MethodSource("processNoPauseSource")
+    void testProcessNotArchivedActive(
+            Channel channel,
+            String archiveStatus,
+            String archiverEndpoint,
+            String submissionBody)
+            throws JsonProcessingException, InterruptedException {
+        paramableAAChannelProcessorTest(
+                mockArchiverAppliance,
+                objectMapper,
+                aaChannelProcessor,
+                channel,
+                archiveStatus,
+                archiverEndpoint,
+                submissionBody);
+    }
+}

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorStatusPauseIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorStatusPauseIT.java
@@ -1,0 +1,82 @@
+package org.phoebus.channelfinder.processors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.phoebus.channelfinder.entity.Channel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.archiveProperty;
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.inactiveProperty;
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.paramableAAChannelProcessorTest;
+
+@WebMvcTest(AAChannelProcessor.class)
+@TestPropertySource(locations = "classpath:application_test.properties", properties = "aa.auto_pause=pvStatus")
+class AAChannelProcessorStatusPauseIT {
+
+    @Autowired
+    AAChannelProcessor aaChannelProcessor;
+
+    MockWebServer mockArchiverAppliance;
+    ObjectMapper objectMapper;
+
+    private static Stream<Arguments> processNoPauseSource() {
+
+        return Stream.of(
+                Arguments.of(
+                        new Channel(
+                                "PVArchivedInactive", "owner", List.of(archiveProperty, inactiveProperty), List.of()),
+                        "Being archived",
+                        "pauseArchivingPV",
+                        "[\"PVArchivedInactive\"]"
+                ),
+                Arguments.of(
+                        new Channel("PVArchivedNotag", "owner", List.of(), List.of()),
+                        "",
+                        "",
+                        ""
+                ));
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockArchiverAppliance = new MockWebServer();
+        mockArchiverAppliance.start(17665);
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void teardown() throws IOException {
+        mockArchiverAppliance.shutdown();
+    }
+
+    @ParameterizedTest
+    @MethodSource("processNoPauseSource")
+    void testProcessNotArchivedActive(
+            Channel channel,
+            String archiveStatus,
+            String archiverEndpoint,
+            String submissionBody)
+            throws JsonProcessingException, InterruptedException {
+        paramableAAChannelProcessorTest(
+                mockArchiverAppliance,
+                objectMapper,
+                aaChannelProcessor,
+                channel,
+                archiveStatus,
+                archiverEndpoint,
+                submissionBody);
+    }
+}

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorTagPauseIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorTagPauseIT.java
@@ -1,0 +1,82 @@
+package org.phoebus.channelfinder.processors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.phoebus.channelfinder.entity.Channel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.archiveProperty;
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.inactiveProperty;
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.paramableAAChannelProcessorTest;
+
+@WebMvcTest(AAChannelProcessor.class)
+@TestPropertySource(locations = "classpath:application_test.properties", properties = "aa.auto_pause=archive")
+class AAChannelProcessorTagPauseIT {
+
+    @Autowired
+    AAChannelProcessor aaChannelProcessor;
+
+    MockWebServer mockArchiverAppliance;
+    ObjectMapper objectMapper;
+
+    private static Stream<Arguments> processNoPauseSource() {
+
+        return Stream.of(
+                Arguments.of(
+                        new Channel(
+                                "PVArchivedInactive", "owner", List.of(archiveProperty, inactiveProperty), List.of()),
+                        "Being archived",
+                        "",
+                        ""),
+                Arguments.of(
+                        new Channel("PVArchivedNotag", "owner", List.of(), List.of()),
+                        "Being archived",
+                        "pauseArchivingPV",
+                        "[\"PVArchivedNotag\"]")
+        );
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockArchiverAppliance = new MockWebServer();
+        mockArchiverAppliance.start(17665);
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void teardown() throws IOException {
+        mockArchiverAppliance.shutdown();
+    }
+
+    @ParameterizedTest
+    @MethodSource("processNoPauseSource")
+    void testProcessNotArchivedActive(
+            Channel channel,
+            String archiveStatus,
+            String archiverEndpoint,
+            String submissionBody)
+            throws JsonProcessingException, InterruptedException {
+        paramableAAChannelProcessorTest(
+                mockArchiverAppliance,
+                objectMapper,
+                aaChannelProcessor,
+                channel,
+                archiveStatus,
+                archiverEndpoint,
+                submissionBody
+                );
+    }
+}

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorTest.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorTest.java
@@ -1,4 +1,4 @@
-package org.phoebus.channelfinder;
+package org.phoebus.channelfinder.processors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,7 +18,7 @@ import static org.phoebus.channelfinder.processors.AAChannelProcessor.ArchivePV;
 class AAChannelProcessorTest {
 
     @Test
-    public void archivePropertyParsePass() {
+    void archivePropertyParsePass() {
         ArchivePV ar = new ArchivePV();
         List<String> testPolicyList = Arrays.asList("Fast", "FastControlled", "Slow", "SlowControlled");
         ar.setPv("sim://testing");
@@ -61,12 +61,13 @@ class AAChannelProcessorTest {
             Arguments.of("ScAn@10.01000", testPolicyList, "SCAN", "10.01000"),
             Arguments.of("MONITOR@0.01", testPolicyList, "MONITOR", "0.01"),
             Arguments.of("MONITOR@1", testPolicyList, "MONITOR", "1"),
-            Arguments.of("scan@.01", testPolicyList, "SCAN", ".01")
+            Arguments.of("scan@.01", testPolicyList, "SCAN", ".01"),
+            Arguments.of("scan@1.01", testPolicyList, "SCAN", "1.01")
         );
     }
 
     @Test
-    public void defaultArchiveTag() {
+    void defaultArchiveTag() {
         ArchivePV ar = new ArchivePV();
         List<String> testPolicyList = Arrays.asList("Fast", "FastControlled", "Slow", "SlowControlled");
         ar.setPv("sim://testing");
@@ -79,7 +80,7 @@ class AAChannelProcessorTest {
     }
 
     @Test
-    public void archivePolicyParsing() {
+    void archivePolicyParsing() {
         ArchivePV ar = new ArchivePV();
         ar.setPv("sim://testingPolicy");
         ar.setPolicy("Fast");
@@ -101,7 +102,7 @@ class AAChannelProcessorTest {
     }
 
     @Test
-    public void json() throws JsonProcessingException {
+    void archivePVJson() throws JsonProcessingException {
         ArchivePV ar1 = new ArchivePV();
         ar1.setPv("sim://testing1");
         ar1.setSamplingParameters("monitor@1.0", new ArrayList<>());

--- a/src/test/resources/application_test.properties
+++ b/src/test/resources/application_test.properties
@@ -95,3 +95,20 @@ elasticsearch.http.port: 9200
 elasticsearch.tag.index = test_${random.int[1,1000]}_cf_tags
 elasticsearch.property.index = test_${random.int[1,1000]}_cf_properties
 elasticsearch.channel.index = test_${random.int[1,1000]}_channelfinder
+
+################ Archiver Appliance Configuration Processor #################
+aa.urls={'default': 'http://localhost:17665'}
+aa.default_alias=default
+aa.enabled=true
+aa.pva=false
+aa.archive_property_name=archive
+aa.archiver_property_name=archiver
+
+# Set the auto pause behaviour
+#
+# Empty for no auto pause
+# Or pvStatus to pause on pvStatus=Inactive
+# Or match archive_property_name to pause on archive_property_name not existing
+# Or both, i.e. aa.auto_pause=pvStatus,archive
+#
+aa.auto_pause=pvStatus,archive


### PR DESCRIPTION
Hi @tynanford @shroffk @mdavidsaver 

This is a proposal to add a new feature to the Channel Finder Archiver Appliance Processor.

The feature would automatically Pause, Resume or Archive PVs tagged with the "archive" infotag.

So in the end you would have:

     * name ArchiveStatus PVStatus - Archiver Appliance Action

     * PV Archived Active - Do Nothing
     * PV Paused Active - Resume
     * PV None Active - Archive
     * PV Archived Inactive - Pause
     * PV Paused Inactive - Nothing
     * PV None Inactive - Nothing

I need to do some more testing but I thought it would be good to get feedback on any problems there might be. 