### PR TITLE
Prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM openjdk:11-jre
 WORKDIR /channelfinder
-ADD https://repo1.maven.org/maven2/org/phoebus/app-channel-channelfinder/4.7.0/app-channel-channelfinder-4.7.0.jar .
+ADD https://repo1.maven.org/maven2/org/phoebus/app-channel-channelfinder/4.7.2/app-channel-channelfinder-4.7.2.jar .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
           echo 'Waiting for Elasticsearch'
           sleep 1
         done
-        java -jar /channelfinder/ChannelFinder-4.7.0.jar"
+        java -jar /channelfinder/ChannelFinder-4.7.2.jar"
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0
@@ -34,7 +34,6 @@ services:
       xpack.security.enabled: "false"
     volumes:
       - channelfinder-es-data:/usr/share/elasticsearch/data
-
 volumes:
   channelfinder-es-data:
     driver: local

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,18 @@
             <groupId>io.netty</groupId> <!-- Need for running tests on mac -->
             <artifactId>netty-all</artifactId>
         </dependency>
+
+        <!-- Metrics -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${spring.boot-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <!-- read properties from the pom file and add them to the application.properties -->

--- a/src/main/java/org/phoebus/channelfinder/Application.java
+++ b/src/main/java/org/phoebus/channelfinder/Application.java
@@ -31,11 +31,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.FileCopyUtils;
 
 @EnableAutoConfiguration
 @ComponentScan(basePackages="org.phoebus.channelfinder")
+@EnableScheduling
 @SpringBootApplication
 public class Application implements ApplicationRunner {
 

--- a/src/main/java/org/phoebus/channelfinder/MetricsService.java
+++ b/src/main/java/org/phoebus/channelfinder/MetricsService.java
@@ -1,0 +1,96 @@
+package org.phoebus.channelfinder;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MultiGauge;
+import io.micrometer.core.instrument.Tags;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+
+@Service
+@PropertySource(value = "classpath:application.properties")
+public class MetricsService {
+
+    @Value("${metrics.tags}")
+    private String[] tags;
+
+    @Value("#{${metrics.properties:{'pvStatus': 'Active'}}}")
+    private Map<String, String> properties;
+
+    private static final Logger logger = Logger.getLogger(MetricsService.class.getName());
+    private static final String METRIC_NAME_CHANNEL_COUNT = "cf_channel_count";
+    private static final String METRIC_NAME_PROPERTIES_COUNT = "cf_properties_count";
+    private static final String METRIC_NAME_TAGS_COUNT = "cf_tags_count";
+    private static final String METRIC_NAME_CHANNEL_COUNT_PER_PROPERTY = "cf_channel_count_per_property";
+    private static final String METRIC_NAME_CHANNEL_COUNT_PER_TAG = "cf_channel_count_per_tag";
+    private static final String METRIC_DESCRIPTION_CHANNEL_COUNT = "Count of channel finder channels";
+    private static final String METRIC_DESCRIPTION_PROPERTIES_COUNT = "Count of channel finder properties";
+    private static final String METRIC_DESCRIPTION_TAGS_COUNT = "Count of channel finder tags";
+    private static final String METRIC_DESCRIPTION_CHANNEL_COUNT_PER_PROPERTY = "Count of channels with specific property with and specific value";
+    private static final String METRIC_DESCRIPTION_CHANNEL_COUNT_PER_TAG = "Count of channels with specific tag";
+
+    private final ChannelRepository channelRepository;
+    private final PropertyRepository propertyRepository;
+    private final TagRepository tagRepository;
+    private final MeterRegistry meterRegistry;
+
+    @Autowired
+    public MetricsService(final ChannelRepository channelRepository, final PropertyRepository propertyRepository, final TagRepository tagRepository,
+                          final MeterRegistry meterRegistry) {
+        this.channelRepository = channelRepository;
+        this.propertyRepository = propertyRepository;
+        this.tagRepository = tagRepository;
+        this.meterRegistry = meterRegistry;
+        registerGaugeMetrics();
+    }
+
+    MultiGauge propertyCounts;
+    MultiGauge tagCounts;
+
+    private void registerGaugeMetrics(){
+        Gauge.builder(METRIC_NAME_CHANNEL_COUNT, () -> channelRepository.count(new LinkedMultiValueMap<>()))
+                .description(METRIC_DESCRIPTION_CHANNEL_COUNT)
+                .register(meterRegistry);
+        Gauge.builder(METRIC_NAME_PROPERTIES_COUNT,
+                        propertyRepository::count)
+                .description(METRIC_DESCRIPTION_PROPERTIES_COUNT)
+                .register(meterRegistry);
+        Gauge.builder(METRIC_NAME_TAGS_COUNT,
+                        tagRepository::count)
+                .description(METRIC_DESCRIPTION_TAGS_COUNT)
+                .register(meterRegistry);
+
+        propertyCounts = MultiGauge.builder(METRIC_NAME_CHANNEL_COUNT_PER_PROPERTY)
+                .description(METRIC_DESCRIPTION_CHANNEL_COUNT_PER_PROPERTY)
+                .register(meterRegistry);
+
+        tagCounts = MultiGauge.builder(METRIC_NAME_CHANNEL_COUNT_PER_TAG)
+                .description(METRIC_DESCRIPTION_CHANNEL_COUNT_PER_TAG)
+                .register(meterRegistry);
+
+    }
+
+    @Scheduled(fixedRate = 10000)
+    public void updateMetrics() {
+        logger.log(Level.INFO, "Updating metrics");
+        propertyCounts.register(
+                properties.entrySet().stream().map(property -> MultiGauge.Row.of(Tags.of(property.getKey(), property.getValue()),
+                                channelRepository.countByProperty(property.getKey(), property.getValue()))).collect(Collectors.toList())
+        );
+        tagCounts.register(
+                Arrays.stream(tags).map(tag -> MultiGauge.Row.of(Tags.of("tag", tag),
+                                channelRepository.countByTag(tag))).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/org/phoebus/channelfinder/PropertyRepository.java
+++ b/src/main/java/org/phoebus/channelfinder/PropertyRepository.java
@@ -18,6 +18,8 @@ import co.elastic.clients.elasticsearch._types.query_dsl.IdsQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.CountRequest;
+import co.elastic.clients.elasticsearch.core.CountResponse;
 import co.elastic.clients.elasticsearch.core.DeleteResponse;
 import co.elastic.clients.elasticsearch.core.ExistsRequest;
 import co.elastic.clients.elasticsearch.core.GetResponse;
@@ -298,8 +300,16 @@ public class PropertyRepository implements CrudRepository<Property, String> {
 
     @Override
     public long count() {
-        // NOT USED
-        return 0;
+        try {
+            CountRequest countRequest = new CountRequest.Builder().index(esService.getES_PROPERTY_INDEX()).build();
+            CountResponse countResponse = client.count(countRequest);
+            return countResponse.count();
+        } catch (ElasticsearchException | IOException e) {
+
+            String message = MessageFormat.format(TextUtil.COUNT_FAILED_CAUSE, "", e.getMessage());
+            logger.log(Level.SEVERE, message, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, message, e);
+        }
     }
 
     /**

--- a/src/main/java/org/phoebus/channelfinder/TagRepository.java
+++ b/src/main/java/org/phoebus/channelfinder/TagRepository.java
@@ -2,7 +2,6 @@ package org.phoebus.channelfinder;
 
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -16,10 +15,10 @@ import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.Result;
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.query_dsl.IdsQuery;
-import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
-import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
+import co.elastic.clients.elasticsearch.core.CountRequest;
+import co.elastic.clients.elasticsearch.core.CountResponse;
 import co.elastic.clients.elasticsearch.core.DeleteResponse;
 import co.elastic.clients.elasticsearch.core.ExistsRequest;
 import co.elastic.clients.elasticsearch.core.GetResponse;
@@ -301,8 +300,16 @@ public class TagRepository implements CrudRepository<Tag, String> {
 
     @Override
     public long count() {
-        // NOT USED
-        return 0;
+        try {
+            CountRequest countRequest = new CountRequest.Builder().index(esService.getES_TAG_INDEX()).build();
+            CountResponse countResponse = client.count(countRequest);
+            return countResponse.count();
+        } catch (ElasticsearchException | IOException e) {
+
+            String message = MessageFormat.format(TextUtil.COUNT_FAILED_CAUSE, "", e.getMessage());
+            logger.log(Level.SEVERE, message, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, message, e);
+        }
     }
 
     /**

--- a/src/main/java/org/phoebus/channelfinder/entity/Tag.java
+++ b/src/main/java/org/phoebus/channelfinder/entity/Tag.java
@@ -165,11 +165,8 @@ public class Tag {
         } else if (!name.equals(other.name))
             return false;
         if (owner == null) {
-            if (other.owner != null)
-                return false;
-        } else if (!owner.equals(other.owner))
-            return false;
-        return true;
+            return other.owner == null;
+        } else return owner.equals(other.owner);
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -100,3 +100,9 @@ aa.enabled=true
 aa.pva=false
 aa.archive_property_name=archive
 aa.archiver_property_name=archiver
+
+############################## Metrics ###############################
+#actuator
+management.endpoints.web.exposure.include=prometheus
+metrics.tags=
+metrics.properties={'pvStatus': 'Active'}

--- a/src/test/java/org/phoebus/channelfinder/AdditionalConfig.java
+++ b/src/test/java/org/phoebus/channelfinder/AdditionalConfig.java
@@ -1,0 +1,14 @@
+package org.phoebus.channelfinder;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class AdditionalConfig {
+    @Bean
+    public MeterRegistry registry() {
+        return new SimpleMeterRegistry();
+    }
+}

--- a/src/test/java/org/phoebus/channelfinder/ChannelRepositoryIT.java
+++ b/src/test/java/org/phoebus/channelfinder/ChannelRepositoryIT.java
@@ -253,6 +253,7 @@ public class ChannelRepositoryIT {
             Assertions.assertEquals(createdSearchResult, foundChannelsResponse, "Failed to find the based on tags name search (all upper case)");
 
         } catch (ResponseStatusException e) {
+            Assertions.fail(e);
         }
     }
 

--- a/src/test/java/org/phoebus/channelfinder/PropertyRepositoryIT.java
+++ b/src/test/java/org/phoebus/channelfinder/PropertyRepositoryIT.java
@@ -12,6 +12,7 @@ import org.phoebus.channelfinder.entity.Channel;
 import org.phoebus.channelfinder.entity.Property;
 import org.phoebus.channelfinder.entity.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.metrics.AutoConfigureMetrics;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
@@ -178,8 +179,28 @@ public class PropertyRepositoryIT {
             // verify the properties were listed as expected
             Assertions.assertEquals(createdProperties, listedProperties, "Failed to list all created properties");
         } catch (Exception e) {
-            e.printStackTrace();
-        } 
+            Assertions.fail(e);
+        }
+    }
+
+    /**
+     * find all properties
+     */
+    @Test
+    public void countXmlProperties() {
+        Property testProperty = new Property("testProperty","testOwner");
+        Property testProperty1 = new Property("testProperty1","testOwner1");
+        List<Property> testProperties = Arrays.asList(testProperty, testProperty1);
+        cleanupTestProperties = testProperties;
+
+        try {
+            Set<Property> createdProperties = Sets.newHashSet(propertyRepository.indexAll(testProperties));
+            long listedPropertiesCount = propertyRepository.count();
+            // verify the properties were listed as expected
+            Assertions.assertEquals(createdProperties.size(), listedPropertiesCount, "Failed to count all created properties");
+        } catch (Exception e) {
+            Assertions.fail(e);
+        }
     }
 
     /**

--- a/src/test/java/org/phoebus/channelfinder/TagRepositoryIT.java
+++ b/src/test/java/org/phoebus/channelfinder/TagRepositoryIT.java
@@ -171,8 +171,7 @@ public class TagRepositoryIT {
             // verify the tag was created as expected
             Assertions.assertEquals(listedTags, createdTags, "Failed to list all created tags");
         } catch (Exception e) {
-            e.printStackTrace();
-        } 
+            Assertions.fail(e);        }
     }
 
     /**

--- a/src/test/java/org/phoebus/channelfinder/epics/EpicsRPCRequest.java
+++ b/src/test/java/org/phoebus/channelfinder/epics/EpicsRPCRequest.java
@@ -5,13 +5,16 @@ import org.epics.nt.NTURIBuilder;
 import org.epics.pvaccess.client.rpc.RPCClientImpl;
 import org.epics.pvdata.pv.PVStructure;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * A simple example client to the channelfinder epics rpc service
  * @author Kunal Shroff
  *
  */
 public class EpicsRPCRequest {
-
+    private static final Logger logger = Logger.getLogger(EpicsRPCRequest.class.getName());
     public static void main(String[] args) {
 
         RPCClientImpl client = new RPCClientImpl(ChannelFinderEpicsService.SERVICE_DESC);
@@ -27,7 +30,7 @@ public class EpicsRPCRequest {
 //            List<Channel> channels = NTXmlUtil.parse(result);
 //            channels.forEach(c -> System.out.println(c.toLog()));
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.log(Level.WARNING, e.getMessage(), e);
         }
     }
 }

--- a/src/test/resources/application_test.properties
+++ b/src/test/resources/application_test.properties
@@ -112,3 +112,11 @@ aa.archiver_property_name=archiver
 # Or both, i.e. aa.auto_pause=pvStatus,archive
 #
 aa.auto_pause=pvStatus,archive
+
+
+############################## Metrics ###############################
+#exclude metrics in tests
+
+management.endpoints.web.exposure.include=prometheus
+metrics.tags=group4_10
+metrics.properties={'group4': '10'}


### PR DESCRIPTION
PR to add metrics api to ChannelFinder.

Allows configuration of what tags and properties are being checked. Gives an example of 

metrics.properties={'pvStatus': 'Active'} to track number of active channels.

Currently hardcoded interval to check channels is 10 seconds. 

Includes some refactoring of some duplicated code.