### PR TITLE
Update version for spring framework boot to 2.7.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot-version>2.7.3</spring.boot-version>
+        <spring.boot-version>2.7.18</spring.boot-version>
         <elasticsearch.version>8.2.0</elasticsearch.version>
         <junit-jupiter.version>5.10.0</junit-jupiter.version>
         <skipITs>true</skipITs>


### PR DESCRIPTION
Update spring framework boot version to 2.7.18.

Update to latest (and last) release on 2.7.* track in preparation of migration to Spring Boot 3.