### PR TITLE
add readthedocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.12"
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: src/site/sphinx/conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  install:
+    - requirements: src/site/sphinx/requirements.txt

--- a/src/site/sphinx/conf.py
+++ b/src/site/sphinx/conf.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import sys, os
-from recommonmark.parser import CommonMarkParser
 
 project = u'ChannelFinder Service'
 copyright = u'Copyright (c) 2010-2020 Brookhaven National Laboratory \n Copyright (c) 2010-2020 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH \n All rights reserved. Use is subject to license terms and conditions.'
@@ -19,9 +18,6 @@ templates_path = ['_templates']
 exclude_trees = ['.build']
 source_suffix = ['.rst', '.md']
 source_encoding = 'utf-8-sig'
-source_parsers = {
-  '.md': CommonMarkParser
-}
 
 # HTML options
 html_theme = 'sphinx_rtd_theme'

--- a/src/site/sphinx/requirements.txt
+++ b/src/site/sphinx/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==7.2.6
+sphinx_rtd_theme==2.0.0
+readthedocs-sphinx-search==0.3.2


### PR DESCRIPTION
Same issue as in phoebus - https://github.com/ControlSystemStudio/phoebus/pull/2929

RTD now requires a configure file for the builds to work - https://readthedocs.org/projects/channelfinder/builds/

Removed recommonmark from conf.py since it is deprecated and there are no .md files in src/site/sphinx anyways