### PR TITLE
Improve configuration of connection to Elasticsearch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.14.2</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -138,7 +138,8 @@ public class ElasticConfig implements ServletContextListener {
         } else {
             client = currentClient;
         }
-        if (Boolean.parseBoolean(createIndices) && esInitialized.compareAndSet(false, true)) {
+        esInitialized.set(!Boolean.parseBoolean(createIndices));
+        if (esInitialized.compareAndSet(false, true)) {
             config.elasticIndexValidation(client);
         }
         return client;

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -109,8 +109,7 @@ public class ElasticConfig implements ServletContextListener {
         } else {
             client = currentClient;
         }
-        esInitialized.set(!Boolean.parseBoolean(createIndices));
-        if (esInitialized.compareAndSet(false, true)) {
+        if (Boolean.parseBoolean(createIndices) && esInitialized.compareAndSet(false, true)) {
             config.elasticIndexValidation(client);
         }
         return client;

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -69,7 +69,6 @@ public class ElasticConfig implements ServletContextListener {
 
     private ElasticsearchClient searchClient;
     private ElasticsearchClient indexClient;
-    private static final AtomicBoolean esInitialized = new AtomicBoolean();
 
     @Value("${elasticsearch.network.host:localhost}")
     private String host;
@@ -138,8 +137,7 @@ public class ElasticConfig implements ServletContextListener {
         } else {
             client = currentClient;
         }
-        esInitialized.set(!Boolean.parseBoolean(createIndices));
-        if (esInitialized.compareAndSet(false, true)) {
+        if (Boolean.parseBoolean(createIndices)) {
             config.elasticIndexValidation(client);
         }
         return client;

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -62,8 +62,6 @@ public class ElasticConfig implements ServletContextListener {
     private ElasticsearchClient indexClient;
     private static final AtomicBoolean esInitialized = new AtomicBoolean();
 
-    @Value("${elasticsearch.cluster.name:elasticsearch}")
-    private String clusterName;
     @Value("${elasticsearch.network.host:localhost}")
     private String host;
     @Value("${elasticsearch.http.port:9200}")

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -17,6 +17,8 @@ package org.phoebus.channelfinder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -64,6 +66,8 @@ public class ElasticConfig implements ServletContextListener {
 
     @Value("${elasticsearch.network.host:localhost}")
     private String host;
+    @Value("${elasticsearch.host_urls:http://localhost:9200}")
+    private String hostUrls;
     @Value("${elasticsearch.http.port:9200}")
     private int port;
     @Value("${elasticsearch.create.indices:true}")
@@ -96,11 +100,15 @@ public class ElasticConfig implements ServletContextListener {
             .addMixIn(Property.class, Property.OnlyProperty.class);
 
     private static ElasticsearchClient createClient(ElasticsearchClient currentClient, ObjectMapper objectMapper,
-                                                    String host, int port, String createIndices, ElasticConfig config) {
+                                                    List<String> hostUrls, String createIndices, ElasticConfig config) {
         ElasticsearchClient client;
         if (currentClient == null) {
             // Create the low-level client
-            RestClient httpClient = RestClient.builder(new HttpHost(host, port)).build();
+            HttpHost[] httpHosts = new HttpHost[hostUrls.size()];
+            for (int i = 0; i < httpHosts.length; ++i) {
+                httpHosts[i] = HttpHost.create(hostUrls.get(i));
+            }
+            RestClient httpClient = RestClient.builder(httpHosts).build();
 
             // Create the Java API Client with the same low level client
             ElasticsearchTransport transport = new RestClientTransport(httpClient, new JacksonJsonpMapper(objectMapper));
@@ -115,15 +123,37 @@ public class ElasticConfig implements ServletContextListener {
         return client;
 
     }
+
+    private List<String> getHostUrls() {
+        String hostUrls = this.hostUrls;
+        boolean hostIsDefault = (host == "localhost");
+        boolean hostUrlsIsDefault = (hostUrls == "http://localhost:9200");
+        boolean portIsDefault = (port == 9200);
+        if (hostUrlsIsDefault) {
+            if (!hostIsDefault || !portIsDefault) {
+                logger.warning("Specifying elasticsearch.network.host and elasticsearch.http.port is deprecated, please consider using elasticsearch.host_urls instead.");
+                hostUrls = "http://" + host + ":" + port;
+            }
+        } else {
+            if (!hostIsDefault) {
+                logger.warning("Only one of elasticsearch.host_urls and elasticsearch.network.host can be set, ignoring elasticsearch.network.host.");
+            }
+            if (!portIsDefault) {
+                logger.warning("Only one of elasticsearch.host_urls and elasticsearch.http.port can be set, ignoring elasticsearch.http.port.");
+            }
+        }
+        return Arrays.asList(hostUrls.split(","));
+    }
+
     @Bean({ "searchClient" })
     public ElasticsearchClient getSearchClient() {
-        searchClient = createClient(searchClient, objectMapper, host, port, createIndices, this);
+        searchClient = createClient(searchClient, objectMapper, getHostUrls(), createIndices, this);
         return searchClient;
     }
 
     @Bean({ "indexClient" })
     public ElasticsearchClient getIndexClient() {
-        indexClient = createClient(indexClient, objectMapper, host, port, createIndices, this);
+        indexClient = createClient(indexClient, objectMapper, getHostUrls(), createIndices, this);
         return indexClient;
     }
 

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -126,12 +126,7 @@ public class ElasticConfig implements ServletContextListener {
             } else if (!config.username.isEmpty() || !config.password.isEmpty()) {
                 final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
                 credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(config.username, config.password));
-                clientBuilder.setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
-                    @Override
-                    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-                        return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-                    }
-                });
+                clientBuilder.setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
             }
             RestClient httpClient = clientBuilder.build();
 

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -121,7 +121,7 @@ public class ElasticConfig implements ServletContextListener {
             if (!config.authorizationHeader.isEmpty()) {
                 clientBuilder.setDefaultHeaders(new Header[] {new BasicHeader("Authorization", config.authorizationHeader)});
                 if (!config.username.isEmpty() || !config.password.isEmpty()) {
-                    logger.warning("elasticsearch.authorization_header is set, ignoring elasticsearch.usernamd and elasticsearch.password.");
+                    logger.warning("elasticsearch.authorization_header is set, ignoring elasticsearch.username and elasticsearch.password.");
                 }
             } else if (!config.username.isEmpty() || !config.password.isEmpty()) {
                 final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -157,8 +157,8 @@ public class ElasticConfig implements ServletContextListener {
 
     private List<String> getHostUrls() {
         String localHostUrls = this.hostUrls;
-        boolean hostIsDefault = (host.equals("localhost"));
-        boolean hostUrlsIsDefault = (localHostUrls.equals("http://localhost:9200"));
+        boolean hostIsDefault = host.equals("localhost");
+        boolean hostUrlsIsDefault = localHostUrls.equals("http://localhost:9200");
         boolean portIsDefault = (port == 9200);
         if (hostUrlsIsDefault) {
             if (!hostIsDefault || !portIsDefault) {

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -156,14 +156,14 @@ public class ElasticConfig implements ServletContextListener {
     }
 
     private List<String> getHostUrls() {
-        String hostUrls = this.hostUrls;
+        String localHostUrls = this.hostUrls;
         boolean hostIsDefault = (host.equals("localhost"));
-        boolean hostUrlsIsDefault = (hostUrls.equals("http://localhost:9200"));
+        boolean hostUrlsIsDefault = (localHostUrls.equals("http://localhost:9200"));
         boolean portIsDefault = (port == 9200);
         if (hostUrlsIsDefault) {
             if (!hostIsDefault || !portIsDefault) {
                 logger.warning("Specifying elasticsearch.network.host and elasticsearch.http.port is deprecated, please consider using elasticsearch.host_urls instead.");
-                hostUrls = "http://" + host + ":" + port;
+                localHostUrls = "http://" + host + ":" + port;
             }
         } else {
             if (!hostIsDefault) {
@@ -173,7 +173,7 @@ public class ElasticConfig implements ServletContextListener {
                 logger.warning("Only one of elasticsearch.host_urls and elasticsearch.http.port can be set, ignoring elasticsearch.http.port.");
             }
         }
-        return Arrays.asList(hostUrls.split(","));
+        return Arrays.asList(localHostUrls.split(","));
     }
 
     @Bean({ "searchClient" })

--- a/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/ElasticConfig.java
@@ -157,8 +157,8 @@ public class ElasticConfig implements ServletContextListener {
 
     private List<String> getHostUrls() {
         String hostUrls = this.hostUrls;
-        boolean hostIsDefault = (host == "localhost");
-        boolean hostUrlsIsDefault = (hostUrls == "http://localhost:9200");
+        boolean hostIsDefault = (host.equals("localhost"));
+        boolean hostUrlsIsDefault = (hostUrls.equals("http://localhost:9200"));
         boolean portIsDefault = (port == 9200);
         if (hostUrlsIsDefault) {
             if (!hostIsDefault || !portIsDefault) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -65,43 +65,17 @@ tag-groups=cf-tags,USER
 
 ############################## Elastic Network And HTTP ###############################
 
-# Elasticsearch, by default, binds itself to the 0.0.0.0 address, and listens
-# on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
-# communication. (the range means that if the port is busy, it will automatically
-# try the next port).
+# Comma-separated list of URLs for the Elasticsearch hosts. All hosts listed
+# here must belong to the same Elasticsearch cluster.
+elasticsearch.host_urls: http://localhost:9200
 
-# Set the bind address specifically (IPv4 or IPv6):
-#
-# network.bind_host: 169.254.42.56
-
-# Set the address other nodes will use to communicate with this node. If not
-# set, it is automatically derived. It must point to an actual IP address.
-#
-# network.publish_host: 192.168.0.1
-
-# Set both 'bind_host' and 'publish_host':
-#
+# Old way of configuring the Elasticsearch host. Deprecated in favor of
+# elasticsearch.host_urls.
 elasticsearch.network.host: localhost
 
-# Set a custom port for the node to node communication (9300 by default):
-#
-#elasticsearch.transport.tcp.port: 9300
-
-# Enable compression for all communication between nodes (disabled by default):
-#
-#transport.tcp.compress: true
-
-# Set a custom port to listen for HTTP traffic:
-#
+# Old way of configuring the Elasticsearch HTTP port. Deprecated in favor of
+# elasticsearch.host_urls.
 elasticsearch.http.port: 9200
-
-# Set a custom allowed content length:
-#
-#http.max_content_length: 100mb
-
-# Disable HTTP completely:
-#
-#http.enabled: false
 
 # Elasticsearch index names and types used by channelfinder, ensure that any changes here should be replicated in the mapping_definitions.sh
 elasticsearch.tag.index = cf_tags

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -77,6 +77,23 @@ elasticsearch.network.host: localhost
 # elasticsearch.host_urls.
 elasticsearch.http.port: 9200
 
+# Value of the Authorization header that is sent with requests to the
+# Elasticsearch sever. This can be used for authentication using tokens or API
+# keys.
+#
+# For example, for token authentication, set this to ?Bearer abcd1234?, where
+# ?abcd1234? is the token. For API key authentication, set this to the Base64
+# encoded version of the concatenation of the API key ID and the API key
+# secret, separated by a colon. See
+# https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.12/_other_authentication_methods.html
+# for details.
+elasticsearch.authorization.header =
+
+# Username and password for authentication with the Elasticsearch server. This
+# is only used if elasticsearch.authorization.header is not set.
+elasticsearch.authorization.username =
+elasticsearch.authorization.password =
+
 # Elasticsearch index names and types used by channelfinder, ensure that any changes here should be replicated in the mapping_definitions.sh
 elasticsearch.tag.index = cf_tags
 elasticsearch.property.index = cf_properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,15 +67,15 @@ tag-groups=cf-tags,USER
 
 # Comma-separated list of URLs for the Elasticsearch hosts. All hosts listed
 # here must belong to the same Elasticsearch cluster.
-elasticsearch.host_urls: http://localhost:9200
+elasticsearch.host_urls=http://localhost:9200
 
 # Old way of configuring the Elasticsearch host. Deprecated in favor of
 # elasticsearch.host_urls.
-elasticsearch.network.host: localhost
+elasticsearch.network.host=localhost
 
 # Old way of configuring the Elasticsearch HTTP port. Deprecated in favor of
 # elasticsearch.host_urls.
-elasticsearch.http.port: 9200
+elasticsearch.http.port=9200
 
 # Value of the Authorization header that is sent with requests to the
 # Elasticsearch sever. This can be used for authentication using tokens or API
@@ -103,7 +103,7 @@ elasticsearch.channel.index = channelfinder
 elasticsearch.query.size = 10000
 
 # Create the Channel Finder indices if they do not exist
-elasticsearch.create.indices: true
+elasticsearch.create.indices=true
 
 ############################## Service Info ###############################
 # ChannelFinder version as defined in the pom file

--- a/src/test/resources/application_test.properties
+++ b/src/test/resources/application_test.properties
@@ -74,7 +74,7 @@ elasticsearch.channel.index = test_${random.int[1,1000]}_channelfinder
 elasticsearch.query.size = 10000
 
 # Create the Channel Finder indices if they do not exist
-elasticsearch.create.indices: true
+elasticsearch.create.indices = true
 
 ############################## Service Info ###############################
 # ChannelFinder version as defined in the pom file

--- a/src/test/resources/application_test.properties
+++ b/src/test/resources/application_test.properties
@@ -61,43 +61,9 @@ tag-groups=cf-tags
 
 ############################## Elastic Network And HTTP ###############################
 
-# Elasticsearch, by default, binds itself to the 0.0.0.0 address, and listens
-# on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
-# communication. (the range means that if the port is busy, it will automatically
-# try the next port).
-
-# Set the bind address specifically (IPv4 or IPv6):
-#
-# network.bind_host: 169.254.42.56
-
-# Set the address other nodes will use to communicate with this node. If not
-# set, it is automatically derived. It must point to an actual IP address.
-#
-# network.publish_host: 192.168.0.1
-
-# Set both 'bind_host' and 'publish_host':
-#
-elasticsearch.network.host: localhost
-
-# Set a custom port for the node to node communication (9300 by default):
-#
-#elasticsearch.transport.tcp.port: 9300
-
-# Enable compression for all communication between nodes (disabled by default):
-#
-#transport.tcp.compress: true
-
-# Set a custom port to listen for HTTP traffic:
-#
-elasticsearch.http.port: 9200
-
-# Set a custom allowed content length:
-#
-#http.max_content_length: 100mb
-
-# Disable HTTP completely:
-#
-#http.enabled: false
+# Comma-separated list of URLs for the Elasticsearch hosts. All hosts listed
+# here must belong to the same Elasticsearch cluster.
+elasticsearch.host_urls=http://localhost:9200
 
 # Elasticsearch index names and types used by channelfinder, ensure that any changes here should be replicated in the mapping_definitions.sh
 elasticsearch.tag.index = test_${random.int[1,1000]}_cf_tags


### PR DESCRIPTION
This PR introduces two major improvements:

1. It is now possible to use multiple URLs instead of a separately configured single hostname and port. This has two benefits: First, multiple hosts can be specified, enabling high-availability when using a multi-host Elasticsearch cluster. Second, the scheme can be specified, thus enabling the user to choose HTTPS instead of HTTP when connecting to the Elasticsearch cluster.
2. Credentials for connecting to the Elasticsearch cluster can be specified. This is required when security is enabled on the ES cluster. The supported methods are username / password, API key, and token-based authentication.

As a side effect, this PR also introduces three minor improvements:

1. The unused `clusterName` variable is removed from `ElasticConfig`.
2. The way how the `esInitialized` flag is used in `ElasticConfig` is changed, fixing a potential race condition.
3. Comments in `application.properties` that apparently were accidentally copied from the Elasticsearch server configuration file and were not relevant to the ChannelFinder service are removed.
