### PR TITLE
Use common version for jackson-core and jackon-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.14.2</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>


### PR DESCRIPTION
As discussed in #127 having a mismatch between the version of `jackson-core` and `jackson-databind` causes problems.

The primary purpose of this PR is to find out whether any of the other changes in #127 cause a failure in the CI checks, or whether these problems also exist in the `master` branch.