### PR TITLE
Allow setting the default archiver to ''

### DIFF
--- a/src/main/java/org/phoebus/channelfinder/processors/ChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/ChannelProcessor.java
@@ -9,7 +9,7 @@ public interface ChannelProcessor {
 
     boolean enabled();
 
-    String processorName();
+    String processorInfo();
 
     void process(List<Channel> channels) throws JsonProcessingException;
 

--- a/src/main/java/org/phoebus/channelfinder/processors/ChannelProcessorManager.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/ChannelProcessorManager.java
@@ -55,7 +55,7 @@ public class ChannelProcessorManager {
 
     @GetMapping("/info")
     public List<String> processorInfo() {
-        return channelProcessorService.getProcessorsNames();
+        return channelProcessorService.getProcessorsInfo();
     }
 
     @PutMapping("/process/all")

--- a/src/main/java/org/phoebus/channelfinder/processors/ChannelProcessorService.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/ChannelProcessorService.java
@@ -25,8 +25,8 @@ public class ChannelProcessorService {
         return channelProcessors.size();
     }
 
-    List<String> getProcessorsNames() {
-        return channelProcessors.stream().map(ChannelProcessor::processorName).collect(Collectors.toList());
+    List<String> getProcessorsInfo() {
+        return channelProcessors.stream().map(ChannelProcessor::processorInfo).collect(Collectors.toList());
     }
 
     /**

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorNoDefaultIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorNoDefaultIT.java
@@ -1,0 +1,84 @@
+package org.phoebus.channelfinder.processors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.phoebus.channelfinder.entity.Channel;
+import org.phoebus.channelfinder.entity.Property;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.activeProperty;
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.archiveProperty;
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.inactiveProperty;
+import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.paramableAAChannelProcessorTest;
+
+@WebMvcTest(AAChannelProcessor.class)
+@TestPropertySource(locations = "classpath:application_test.properties", properties = "aa.urls:{'default': '','aa': 'http://localhost:17665'}")
+class AAChannelProcessorNoDefaultIT {
+    protected static Property archiverProperty = new Property("archiver", "owner", "aa");
+
+    @Autowired
+    AAChannelProcessor aaChannelProcessor;
+
+    MockWebServer mockArchiverAppliance;
+    ObjectMapper objectMapper;
+
+    private static Stream<Arguments> processNoPauseSource() {
+
+        return Stream.of(
+                Arguments.of(
+                        new Channel("PVNoneActive", "owner", List.of(archiveProperty, activeProperty), List.of()),
+                        "",
+                        "",
+                        ""),
+                Arguments.of(
+                        new Channel("PVNoneActiveArchiver", "owner", List.of(archiveProperty, activeProperty, archiverProperty), List.of()),
+                        "Not being archived",
+                        "archivePV",
+                        "[{\"pv\":\"PVNoneActiveArchiver\"}]")
+        );
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockArchiverAppliance = new MockWebServer();
+        mockArchiverAppliance.start(17665);
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void teardown() throws IOException {
+        mockArchiverAppliance.shutdown();
+    }
+
+    @ParameterizedTest
+    @MethodSource("processNoPauseSource")
+    void testProcessNotArchivedActive(
+            Channel channel,
+            String archiveStatus,
+            String archiverEndpoint,
+            String submissionBody)
+            throws JsonProcessingException, InterruptedException {
+        paramableAAChannelProcessorTest(
+                mockArchiverAppliance,
+                objectMapper,
+                aaChannelProcessor,
+                channel,
+                archiveStatus,
+                archiverEndpoint,
+                submissionBody
+                );
+    }
+}


### PR DESCRIPTION
Adds a test for this option in AAChannelProcessorNoDefaultIT 

Tests both a channel where the archiver is implicitly set to the '' url and a correctly existing archiver.