### PR TITLE
Disable listening on ipv6 in the docker compose files.

### DIFF
--- a/docker-compose-integrationtest.yml
+++ b/docker-compose-integrationtest.yml
@@ -40,7 +40,7 @@ services:
       embedded_ldap.enabled: "false"
       demo_auth.enabled: "true"
       skipITCoverage: "true"
-      EPICS_PVA_ENABLE_IP6: "false"
+      EPICS_PVAS_INTF_ADDR_LIST: "0.0.0.0"
     command: >
       /bin/bash -c "
         if [ ${skipITCoverage} == false ]; then
@@ -81,7 +81,3 @@ volumes:
 networks:
   channelfinder-net:
     driver: bridge
-    enable_ipv6: true
-    ipam:
-      config:
-        - subnet: 2001:0DB8::/112

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       discovery.type: single-node
       bootstrap.memory_lock: "true"
       xpack.security.enabled: "false"
+      EPICS_PVAS_INTF_ADDR_LIST: "0.0.0.0"
     volumes:
       - channelfinder-es-data:/usr/share/elasticsearch/data
 volumes:
@@ -41,7 +42,3 @@ volumes:
 networks:
   channelfinder-net:
     driver: bridge
-    enable_ipv6: true
-    ipam:
-      config:
-        - subnet: 2001:0DB8::/112

--- a/src/site/sphinx/config.rst
+++ b/src/site/sphinx/config.rst
@@ -84,3 +84,22 @@ To set the auto pause behaviour, configure the parameter :ref:`aa.auto_pause`. S
 and resume on pvStatus=Active. Set to archive to pause on archive_property_name not existing. Set to both to pause on pvStatus=Inactive and archive_property_name::
 
     aa.auto_pause=pvStatus,archive
+
+
+EPICS PV Access Server
+----------------------
+
+ChannelFinder provides an EPICS PV Access Server to access the api through pvAccess.
+There are a number of options that can be set such EPICS_PVA_ADDR_LIST. To see the
+full list go to https://github.com/ControlSystemStudio/phoebus/blob/v4.7.3/core/pva/src/main/java/org/epics/pva/PVASettings.java
+
+Since it is common to run ChannelFinder inside a docker container which by default does not support IPv6 you may have
+error messages in the logs about launching the EPICS PV Access service. If you only wish to have the EPICS Service available on
+IPv4 you can set the environment variable
+
+    EPICS_PVAS_INTF_ADDR_LIST="0.0.0.0"
+
+Or to not have the EPICS PV Access Server listen, then:
+
+    EPICS_PVAS_INTF_ADDR_LIST="0.0.0.0"
+


### PR DESCRIPTION
Should reduce the erroneous logs from the pvAccess server in docker tests.

See https://github.com/ControlSystemStudio/phoebus/blob/5a69830bd5b4be7a23a1359dcb49a62de61049cb/core/pva/src/main/java/org/epics/pva/PVASettings.java#L130 for details of EPICS_PVAS_INTF_ADDR_LIST