### PR TITLE
Update to eclipsetemurin docker image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,6 +4,8 @@ name: Release docker image
 on:
   push:
     branches: [ "master" ]
+    tags:
+      - '**'
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jre
+FROM eclipse-temurin:17-jre
 
 # deployment unit
 COPY target/ChannelFinder-*.jar /channelfinder/ChannelFinder-*.jar

--- a/Dockerfile.integrationtest
+++ b/Dockerfile.integrationtest
@@ -16,7 +16,7 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 # ------------------------------------------------------------------------------
 
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 
 # deployment unit
 COPY target/ChannelFinder-*.jar /channelfinder/ChannelFinder-*.jar


### PR DESCRIPTION
docker image openjdk:17-jre has been depreceated
 so need to swap to eclipsetemurin

 Also make sure to publish docker image on new tags