### PR TITLE
Update config docs, add example of AA plugin

### DIFF
--- a/src/site/sphinx/config.rst
+++ b/src/site/sphinx/config.rst
@@ -13,10 +13,23 @@ application.properties
 
 The following describe valid keys in an application.properties.
 
-HTTP Server
-^^^^^^^^^^^
 
-TODO
+Server
+^^^^^^
+
+HTTP Config
+"""""""""""
+    server.port - HTTPS port for Channel Finder API
+
+    server.http.enable - true/false to toggle HTTP access
+
+    server.http.port - HTTP port for Channel Finder API
+
+SSL Config
+""""""""""
+
+    server.ssl.key-store - Path to SSL keystore file
+
 
 LDAP Client
 ^^^^^^^^^^^
@@ -56,11 +69,27 @@ Comma ',' separated lists of LDAP group names. ::
 .. _ldap-embedded:
 
 Embedded LDAP Server
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
 When :ref:`conf-embedded_ldap.enabled` is **true**,
 An LDAP server is run by the channelfinder service process and is initially populated
 with entries read from the file referenced by :ref:`conf-embedded_ldap.urls`.
+
+Elastic Search
+^^^^^^^^^^^^^^
+
+HTTP Config
+"""""""""""
+    elasticsearch.host_urls - Comma-separated list of URLs for the Elasticsearch hosts. All hosts listed here must belong to the same Elasticsearch cluster.
+
+    elasticsearch.query.size - Maximum size of elasticsearch queries. WARNING this property is used to update elastic maxResultWindow size. UPDATE  with care.
+
+    elasticsearch.create.indices - true/false to enable Channel Finder to automatically create elastic search indicies
+
+SSL Config
+""""""""""
+
+    server.ssl.key-store - Path to SSL keystore file
 
 Archiver Appliance Configuration Processor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,11 +108,38 @@ The properties checked for setting a PV to be archived are ::
     aa.archive_property_name=archive
     aa.archiver_property_name=archiver
 
-
 To set the auto pause behaviour, configure the parameter :ref:`aa.auto_pause`. Set to pvStatus to pause on pvStatus=Inactive,
 and resume on pvStatus=Active. Set to archive to pause on archive_property_name not existing. Set to both to pause on pvStatus=Inactive and archive_property_name::
 
     aa.auto_pause=pvStatus,archive
+
+AA Plugin Example
+"""""""""""""""""
+
+A common use case for the archiver appliance processor is for sites that use the Recsync project to populate Channel Finder.
+With the reccaster module, info tags in the IOC database specify the archiving parameters and these properties will be pushed to Channel Finder by the recceiver service.
+
+In the example database below, the AA plugin will make requests to archive each PV.
+The plugin will request MyPV to be archived with the SCAN method and sampling rate of 10 seconds to the "aa_appliance0" instance specified in aa.urls property.
+MyPV2 will use the MONITOR method and a sampling rate of 0.1 seconds, and the request will be sent to the URL mapped to the the "aa_appliance1: key.
+MyPolicyPV shows an example that uses an archiver appliance "Named Policy" string and also uses the URL specified in the aa.default_alias property since the "archiver" tag is missing.
+
+For named policy PVs, the AA plugin will first check that the named policy exists in the appliance using the getPolicyList BPL endpoint.
+
+.. code-block::
+
+   record(ao, "MyPV") {
+       info(archive,  "scan@10")
+       info(archiver, "aa_appliance0")
+   }
+   record(ao, "MyPV2") {
+      info(archive,  "monitor@0.1")
+      info(archiver, "aa_appliance1")
+   }
+   record(ao, "MyPolicyPV") {
+      info(archive,  "AAPolicyName")
+      # no archiver tag so PV sent to archiver in aa.default_alias
+   }
 
 
 EPICS PV Access Server


### PR DESCRIPTION
I feel like the full list of configuration docs should probably be auto-generated from application.properties, similar Phoebus's preference settings documentation. But for now, added a few settings that seemed important to me and added a section on the AA plugin with a database example.