### PR TITLE
Enable reproducible builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
         <spring.boot-version>2.7.3</spring.boot-version>
         <elasticsearch.version>8.11.2</elasticsearch.version>
         <junit-jupiter.version>5.10.0</junit-jupiter.version>


### PR DESCRIPTION
Hello, and thanks for this project!

This PR enables reproducible builds, which are useful for checking that files were not tampered with.

By setting the timestamp of produced files, we enable artifacts to be bit-for-bit reproducible from one build to another.

Tested by running:

    mvn artifact:check-buildplan
    mvn clean install
    mvn clean artifact:compare

Done with the help of these guides:

- https://reproducible-builds.org/docs/jvm/
- https://maven.apache.org/guides/mini/guide-reproducible-builds.html