### PR TITLE
Change camelCase parameters in archivePV request to lowercase

### DIFF
--- a/src/main/java/org/phoebus/channelfinder/processors/aa/ArchivePVOptions.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/ArchivePVOptions.java
@@ -2,6 +2,7 @@ package org.phoebus.channelfinder.processors.aa;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -12,7 +13,9 @@ public class ArchivePVOptions {
     private static final Logger logger = Logger.getLogger(ArchivePVOptions.class.getName());
 
     private String pv;
+    @JsonProperty("samplingmethod")
     private String samplingMethod;
+    @JsonProperty("samplingperiod")
     private String samplingPeriod;
     private String policy;
     @JsonIgnore

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorTest.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorTest.java
@@ -114,7 +114,7 @@ class AAChannelProcessorTest {
         ObjectMapper objectMapper = new ObjectMapper();
         String str = objectMapper.writeValueAsString(List.of(ar1, ar2));
 
-        String expectedString = "[{\"pv\":\"sim://testing1\",\"samplingMethod\":\"MONITOR\",\"samplingPeriod\":\"1.0\"},{\"pv\":\"sim://testing2\",\"samplingMethod\":\"SCAN\",\"samplingPeriod\":\"0.2\"}]";
+        String expectedString = "[{\"pv\":\"sim://testing1\",\"samplingmethod\":\"MONITOR\",\"samplingperiod\":\"1.0\"},{\"pv\":\"sim://testing2\",\"samplingmethod\":\"SCAN\",\"samplingperiod\":\"0.2\"}]";
         Assertions.assertEquals(str, expectedString);
 
         // Only a pv name


### PR DESCRIPTION
Archiver seems to expect lowercase parameters in the archivePV request. As the AA processor uses camelCase in the request, i.e. `samplingMethod` and `samplingPeriod` instead of `samplingmethod` and `samplingperiod`, Archiver ignores the specified archiving configuration.

Tested using Archiver Appliance v1.1.0 and RecSync from a recent commit on the master branch ([d9a474d](https://github.com/ChannelFinder/recsync/tree/d9a474d411a669a2f3db4eed5abeb19fb27de170)).

Addresses #166, assuming it is getting fixed.