### PR TITLE
Fix static resource loading in ChannelFinder WebUI

### DIFF
--- a/src/main/resources/static/cf.js
+++ b/src/main/resources/static/cf.js
@@ -5,7 +5,7 @@ var ChannelFinder = (function() {
 
 function ChannelFinder(opts) {
     opts = opts || {};
-    this.baseurl = opts.baseurl || "/ChannelFinder";
+    this.baseurl = opts.baseurl || "ChannelFinder";
 }
 
 function doReq(suffix, opts) {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta http-equiv="Content-Type" charset="UTF-8" />
 <title>ChannelFinder Admin</title>
-<link rel="stylesheet" type="text/css" href="/cfmanage.css">
-<script src="/cf.js"></script>
-<script src="/cfmanage.js"></script>
+<link rel="stylesheet" type="text/css" href="cfmanage.css">
+<script src="cf.js"></script>
+<script src="cfmanage.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Update relative paths for static resources in index.html to ensure proper loading when accessed under a custom context path. Previously, absolute paths caused 404 errors when the service was deployed with a non-root context path.

Example:
https://services.com/channel-finder/