### PR TITLE
Maven CI: Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build with Maven
       run: mvn --batch-mode --update-snapshots package
     - run: mkdir staging && cp target/*.jar staging
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Package
         path: staging


### PR DESCRIPTION
The jobs are failing because it uses a deprecated version of `actions/upload-artifact: v3`.