### PR TITLE
Fix the property metrics for prometheus

### DIFF
--- a/src/main/java/org/phoebus/channelfinder/MetricsService.java
+++ b/src/main/java/org/phoebus/channelfinder/MetricsService.java
@@ -2,22 +2,16 @@ package org.phoebus.channelfinder;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.MultiGauge;
-import io.micrometer.core.instrument.Tags;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,10 +22,11 @@ public class MetricsService {
     public static final String CF_PROPERTY_COUNT = "cf.property.count";
     public static final String CF_TAG_COUNT = "cf.tag.count";
     public static final String CF_PROPERTY_FORMAT_STRING = "cf.%s.channel.count";
-    public static final String CF_CHANNEL_COUNT = "cf.channel.count";
+    public static final String CF_TAG_ON_CHANNELS_COUNT = "cf.tag_on_channels.count";
     private static final String METRIC_DESCRIPTION_TOTAL_CHANNEL_COUNT = "Count of all ChannelFinder channels";
     private static final String METRIC_DESCRIPTION_PROPERTY_COUNT = "Count of all ChannelFinder properties";
     private static final String METRIC_DESCRIPTION_TAG_COUNT = "Count of all ChannelFinder tags";
+    private static final String BASE_UNIT = "channels";
 
     private final ChannelRepository channelRepository;
     private final PropertyRepository propertyRepository;
@@ -85,13 +80,12 @@ public class MetricsService {
     }
 
     private void registerTagMetrics() {
-
         // Add tags
         for (String tag : tags) {
-            Gauge.builder(CF_CHANNEL_COUNT, () -> channelRepository.countByTag(tag))
+            Gauge.builder(CF_TAG_ON_CHANNELS_COUNT, () -> channelRepository.countByTag(tag))
                 .description("Number of channels with tag")
                 .tag("tag", tag)
-                .baseUnit("channels")
+                .baseUnit(BASE_UNIT)
                 .register(meterRegistry);
         }
     }
@@ -103,7 +97,7 @@ public class MetricsService {
             Gauge.builder(String.format(CF_PROPERTY_FORMAT_STRING, propertyName), () -> channelRepository.countByProperty(propertyName, propertyValue))
                 .description(String.format("Number of channels with property '%s'", propertyName))
                 .tag(propertyName, propertyValue)
-                .baseUnit("channels")
+                .baseUnit(BASE_UNIT)
                 .register(meterRegistry))
         );
     }

--- a/src/main/java/org/phoebus/channelfinder/MetricsService.java
+++ b/src/main/java/org/phoebus/channelfinder/MetricsService.java
@@ -143,7 +143,11 @@ public class MetricsService {
         List<Tag> metricTags = new ArrayList<>();
         for (Map.Entry<String, String> entry : multiValueMap.toSingleValueMap().entrySet()) {
             if (entry.getKey().endsWith(NEGATE)) {
-                metricTags.add(new ImmutableTag(entry.getKey().substring(0, entry.getKey().length() - 1), NOT_SET));
+                if (entry.getValue().equals("*")) {
+                    metricTags.add(new ImmutableTag(entry.getKey().substring(0, entry.getKey().length() - 1), NOT_SET));
+                } else {
+                    metricTags.add(new ImmutableTag(entry.getKey().substring(0, entry.getKey().length() - 1), NEGATE + entry.getValue()));
+                }
             } else {
                 metricTags.add(new ImmutableTag(entry.getKey(), entry.getValue()));
             }

--- a/src/main/java/org/phoebus/channelfinder/MetricsService.java
+++ b/src/main/java/org/phoebus/channelfinder/MetricsService.java
@@ -1,18 +1,23 @@
 package org.phoebus.channelfinder;
 
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.ImmutableTag;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import javax.annotation.PostConstruct;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.Map.Entry;
 
 @Service
 @PropertySource(value = "classpath:application.properties")
@@ -21,12 +26,15 @@ public class MetricsService {
     public static final String CF_TOTAL_CHANNEL_COUNT = "cf.total.channel.count";
     public static final String CF_PROPERTY_COUNT = "cf.property.count";
     public static final String CF_TAG_COUNT = "cf.tag.count";
-    public static final String CF_PROPERTY_FORMAT_STRING = "cf.%s.channel.count";
+    public static final String CF_CHANNEL_COUNT = "cf.channel.count";
     public static final String CF_TAG_ON_CHANNELS_COUNT = "cf.tag_on_channels.count";
     private static final String METRIC_DESCRIPTION_TOTAL_CHANNEL_COUNT = "Count of all ChannelFinder channels";
     private static final String METRIC_DESCRIPTION_PROPERTY_COUNT = "Count of all ChannelFinder properties";
     private static final String METRIC_DESCRIPTION_TAG_COUNT = "Count of all ChannelFinder tags";
+    private static final String METRIC_DESCRIPTION_CHANNEL_COUNT = "Count of all ChannelFinder channels with set properties";
     private static final String BASE_UNIT = "channels";
+    private static final String NEGATE = "!";
+    public static final String NOT_SET = "-";
 
     private final ChannelRepository channelRepository;
     private final PropertyRepository propertyRepository;
@@ -90,15 +98,66 @@ public class MetricsService {
         }
     }
 
+    public static List<MultiValueMap<String, String>> generateAllMultiValueMaps(Map<String, List<String>> properties) {
+        List<MultiValueMap<String, String>> allMultiValueMaps = new ArrayList<>();
+
+        if (properties.isEmpty()) {
+            allMultiValueMaps.add(new LinkedMultiValueMap<>()); // Add an empty map for the case where all are null
+            return allMultiValueMaps;
+        }
+
+        List<Entry<String, List<String>>> entries = new ArrayList<>(properties.entrySet());
+        generateCombinations(entries, 0, new LinkedMultiValueMap<>(), allMultiValueMaps);
+
+        return allMultiValueMaps;
+    }
+
+    private static void generateCombinations(
+        List<Entry<String, List<String>>> entries,
+        int index,
+        MultiValueMap<String, String> currentMap,
+        List<MultiValueMap<String, String>> allMultiValueMaps) {
+
+        if (index == entries.size()) {
+            allMultiValueMaps.add(new LinkedMultiValueMap<>(currentMap));
+            return;
+        }
+
+        Entry<String, List<String>> currentEntry = entries.get(index);
+        String key = currentEntry.getKey();
+        List<String> values = currentEntry.getValue();
+
+        // Add the other options
+        for (String value : values) {
+            LinkedMultiValueMap<String, String> nextMapWithValue = new LinkedMultiValueMap<>(currentMap);
+            if (value.startsWith(NEGATE)) {
+                nextMapWithValue.add(key + NEGATE, value.substring(1));
+            } else {
+                nextMapWithValue.add(key, value);
+            }
+            generateCombinations(entries, index + 1, nextMapWithValue, allMultiValueMaps);
+        }
+    }
+
+    private List<Tag> metricTagsFromMultiValueMap(MultiValueMap<String, String> multiValueMap) {
+        List<Tag> metricTags = new ArrayList<>();
+        for (Map.Entry<String, String> entry : multiValueMap.toSingleValueMap().entrySet()) {
+            if (entry.getKey().endsWith(NEGATE)) {
+                metricTags.add(new ImmutableTag(entry.getKey().substring(0, entry.getKey().length() - 1), NOT_SET));
+            } else {
+                metricTags.add(new ImmutableTag(entry.getKey(), entry.getValue()));
+            }
+        }
+        return metricTags;
+    }
     private void registerPropertyMetrics() {
         Map<String, List<String>> properties = parseProperties();
 
-        properties.forEach((propertyName, propertyValues) -> propertyValues.forEach(propertyValue ->
-            Gauge.builder(String.format(CF_PROPERTY_FORMAT_STRING, propertyName), () -> channelRepository.countByProperty(propertyName, propertyValue))
-                .description(String.format("Number of channels with property '%s'", propertyName))
-                .tag(propertyName, propertyValue)
-                .baseUnit(BASE_UNIT)
-                .register(meterRegistry))
+        List<MultiValueMap<String, String>> combinations = generateAllMultiValueMaps(properties);
+        combinations.forEach(map -> Gauge.builder(CF_CHANNEL_COUNT, () -> channelRepository.count(map))
+            .description(METRIC_DESCRIPTION_CHANNEL_COUNT)
+            .tags(metricTagsFromMultiValueMap(map))
+            .register(meterRegistry)
         );
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -137,4 +137,4 @@ aa.auto_pause=
 #actuator
 management.endpoints.web.exposure.include=prometheus, metrics, health, info
 metrics.tags=
-metrics.properties={{'pvStatus', 'Active'}, {'pvStatus', 'Inactive'}}
+metrics.properties=pvStatus:Active, Inactive

--- a/src/site/sphinx/aa_processor.rst
+++ b/src/site/sphinx/aa_processor.rst
@@ -1,0 +1,58 @@
+.. _aa_processor:
+Archiver Appliance Processor
+============================
+
+.. _aa_processor_config:
+Configuration
+-------------
+To enable the archiver appliance configuration processor, set the property :ref:`aa.enabled` to **true**.
+
+A list of archiver appliance URLs and aliases. ::
+
+    aa.urls={'default': 'http://archiver-01.example.com:17665', 'neutron-controls': 'http://archiver-02.example.com:17665'}
+
+To set the choice of default archiver appliance, set the property :ref:`aa.default_alias` to the alias of the default archiver appliance. This setting can also be a comma-separated list if you want multiple default archivers.
+
+To pass the PV as "pva://PVNAME" to the archiver appliance, set the property :ref:`aa.pva` to **true**.
+
+The properties checked for setting a PV to be archived are ::
+
+    aa.archive_property_name=archive
+    aa.archiver_property_name=archiver
+
+To set the auto pause behaviour, configure the parameter :ref:`aa.auto_pause`. Set to pvStatus to pause on pvStatus=Inactive,
+and resume on pvStatus=Active. Set to archive to pause on archive_property_name not existing. Set to both to pause on pvStatus=Inactive and archive_property_name::
+
+    aa.auto_pause=pvStatus,archive
+
+AA Plugin Example
+-----------------
+
+A common use case for the archiver appliance processor is for sites that use the Recsync project to populate Channel Finder.
+With the reccaster module, info tags in the IOC database specify the archiving parameters and these properties will be pushed to Channel Finder by the recceiver service.
+
+In the example database below, the AA plugin will make requests to archive each PV.
+The plugin will request MyPV to be archived with the SCAN method and sampling rate of 10 seconds to the "aa_appliance0" instance specified in aa.urls property.
+MyPV2 will use the MONITOR method and a sampling rate of 0.1 seconds, and the request will be sent to the URL mapped to the the "aa_appliance1: key.
+MyPolicyPV shows an example that uses an archiver appliance "Named Policy" string and also uses the URL specified in the aa.default_alias property since the "archiver" tag is missing.
+
+For named policy PVs, the AA plugin will first check that the named policy exists in the appliance using the getPolicyList BPL endpoint.
+
+.. code-block::
+
+   record(ao, "MyPV") {
+       info(archive,  "scan@10")
+       info(archiver, "aa_appliance0")
+   }
+   record(ao, "MyPV2") {
+      info(archive,  "monitor@0.1")
+      info(archiver, "aa_appliance1")
+   }
+   record(ao, "MyPVWithMultipleArchivers") {
+      info(archive,  "monitor@0.1")
+      info(archiver, "aa_appliance0,aa_appliance1")
+   }
+   record(ao, "MyPolicyPV") {
+      info(archive,  "AAPolicyName")
+      # no archiver tag so PV sent to archiver in aa.default_alias
+   }

--- a/src/site/sphinx/config.rst
+++ b/src/site/sphinx/config.rst
@@ -91,124 +91,16 @@ SSL Config
 
     server.ssl.key-store - Path to SSL keystore file
 
-Archiver Appliance Configuration Processor
+Archiver Appliance Processor Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To enable the archiver appliance configuration processor, set the property :ref:`aa.enabled` to **true**.
 
-A list of archiver appliance URLs and aliases. ::
-
-    aa.urls={'default': 'http://archiver-01.example.com:17665', 'neutron-controls': 'http://archiver-02.example.com:17665'}
-
-To set the choice of default archiver appliance, set the property :ref:`aa.default_alias` to the alias of the default archiver appliance. This setting can also be a comma-separated list if you want multiple default archivers.
-
-To pass the PV as "pva://PVNAME" to the archiver appliance, set the property :ref:`aa.pva` to **true**.
-
-The properties checked for setting a PV to be archived are ::
-
-    aa.archive_property_name=archive
-    aa.archiver_property_name=archiver
-
-To set the auto pause behaviour, configure the parameter :ref:`aa.auto_pause`. Set to pvStatus to pause on pvStatus=Inactive,
-and resume on pvStatus=Active. Set to archive to pause on archive_property_name not existing. Set to both to pause on pvStatus=Inactive and archive_property_name::
-
-    aa.auto_pause=pvStatus,archive
-
-AA Plugin Example
-"""""""""""""""""
-
-A common use case for the archiver appliance processor is for sites that use the Recsync project to populate Channel Finder.
-With the reccaster module, info tags in the IOC database specify the archiving parameters and these properties will be pushed to Channel Finder by the recceiver service.
-
-In the example database below, the AA plugin will make requests to archive each PV.
-The plugin will request MyPV to be archived with the SCAN method and sampling rate of 10 seconds to the "aa_appliance0" instance specified in aa.urls property.
-MyPV2 will use the MONITOR method and a sampling rate of 0.1 seconds, and the request will be sent to the URL mapped to the the "aa_appliance1: key.
-MyPolicyPV shows an example that uses an archiver appliance "Named Policy" string and also uses the URL specified in the aa.default_alias property since the "archiver" tag is missing.
-
-For named policy PVs, the AA plugin will first check that the named policy exists in the appliance using the getPolicyList BPL endpoint.
-
-.. code-block::
-
-   record(ao, "MyPV") {
-       info(archive,  "scan@10")
-       info(archiver, "aa_appliance0")
-   }
-   record(ao, "MyPV2") {
-      info(archive,  "monitor@0.1")
-      info(archiver, "aa_appliance1")
-   }
-   record(ao, "MyPVWithMultipleArchivers") {
-      info(archive,  "monitor@0.1")
-      info(archiver, "aa_appliance0,aa_appliance1")
-   }
-   record(ao, "MyPolicyPV") {
-      info(archive,  "AAPolicyName")
-      # no archiver tag so PV sent to archiver in aa.default_alias
-   }
+See :ref:`_aa_processor_config`.
 
 Metrics
 ^^^^^^^
 
-Metrics can be exposed by setting the `management.endpoints.web.exposure.include=prometheus` property.
+See :ref:`_metrics`.
 
-.. code-block::
-
-    management.endpoints.web.exposure.include=prometheus, metrics, health, info
-
-Adding the prometheus property will expose the prometheus endpoint which can be scraped by prometheus.
-
-The default metrics exposed by specifying "metrics" are:
-
-.. code-block::
-
-    cf.total.channel.count - Count of all ChannelFinder channels
-    cf.property.count - Count of all Property Names
-    cf.tag.count - Count of all tags
-
-Tag Metrics
-"""""""""""
-
-You can also set the metrics.tags to add counts of number of channels per tag. These are exposed as
-`cf.tag_on_channels.count{tag=tagName}`. For example
-
-.. code-block::
-
-    metrics.tags=Accelerator, Beamline1, Beamline2, Beamline3
-
-Would produce metrics:
-
-.. code-block::
-
-    cf.tag_on_channels.count=109
-    cf.tag_on_channels.count{tag=Accelerator} = 100
-    cf.tag_on_channels.count{tag=Beamline1} = 3
-    cf.tag_on_channels.count{tag=Beamline2} = 3
-    cf.tag_on_channels.count{tag=Beamline3} = 3
-
-Property Metrics
-""""""""""""""""
-
-You can also set the metrics.properties to add counts of number of channels per property and value. These are exposed as
-`cf_propertyName_channels_count{propertyName=propertyValue}`. For example:
-
-
-.. code-block::
-
-    metrics.properties=pvStatus:Active, Inactive; archive: default, fast, slow; archiver: aa_beamline, aa_acccelerator
-
-Would produce metrics:
-
-.. code-block::
-
-    cf.pvStatus.channel.count=100
-    cf.pvStatus.channel.count{pvStatus=Active}=50
-    cf.pvStatus.channel.count{pvStatus=Active}=50
-    cf.archive.channel.count=21
-    cf.archive.channel.count{archive=default}=1
-    cf.archive.channel.count{archive=fast}=10
-    cf.archive.channel.count{archive=slow}=10
-    cf.archiver.channel.count=20
-    cf.archive.channel.count{archive=aa_beamline}=10
-    cf.archive.channel.count{archive=aa_acccelerator}=10
 
 EPICS PV Access Server
 ----------------------

--- a/src/site/sphinx/config.rst
+++ b/src/site/sphinx/config.rst
@@ -145,6 +145,70 @@ For named policy PVs, the AA plugin will first check that the named policy exist
       # no archiver tag so PV sent to archiver in aa.default_alias
    }
 
+Metrics
+^^^^^^^
+
+Metrics can be exposed by setting the `management.endpoints.web.exposure.include=prometheus` property.
+
+.. code-block::
+
+    management.endpoints.web.exposure.include=prometheus, metrics, health, info
+
+Adding the prometheus property will expose the prometheus endpoint which can be scraped by prometheus.
+
+The default metrics exposed by specifying "metrics" are:
+
+.. code-block::
+
+    cf.total.channel.count - Count of all ChannelFinder channels
+    cf.property.count - Count of all Property Names
+    cf.tag.count - Count of all tags
+
+Tag Metrics
+"""""""""""
+
+You can also set the metrics.tags to add counts of number of channels per tag. These are exposed as
+`cf.tag_on_channels.count{tag=tagName}`. For example
+
+.. code-block::
+
+    metrics.tags=Accelerator, Beamline1, Beamline2, Beamline3
+
+Would produce metrics:
+
+.. code-block::
+
+    cf.tag_on_channels.count=109
+    cf.tag_on_channels.count{tag=Accelerator} = 100
+    cf.tag_on_channels.count{tag=Beamline1} = 3
+    cf.tag_on_channels.count{tag=Beamline2} = 3
+    cf.tag_on_channels.count{tag=Beamline3} = 3
+
+Property Metrics
+""""""""""""""""
+
+You can also set the metrics.properties to add counts of number of channels per property and value. These are exposed as
+`cf_propertyName_channels_count{propertyName=propertyValue}`. For example:
+
+
+.. code-block::
+
+    metrics.properties=pvStatus:Active, Inactive; archive: default, fast, slow; archiver: aa_beamline, aa_acccelerator
+
+Would produce metrics:
+
+.. code-block::
+
+    cf.pvStatus.channel.count=100
+    cf.pvStatus.channel.count{pvStatus=Active}=50
+    cf.pvStatus.channel.count{pvStatus=Active}=50
+    cf.archive.channel.count=21
+    cf.archive.channel.count{archive=default}=1
+    cf.archive.channel.count{archive=fast}=10
+    cf.archive.channel.count{archive=slow}=10
+    cf.archiver.channel.count=20
+    cf.archive.channel.count{archive=aa_beamline}=10
+    cf.archive.channel.count{archive=aa_acccelerator}=10
 
 EPICS PV Access Server
 ----------------------
@@ -162,29 +226,3 @@ IPv4 you can set the environment variable
 Or to not have the EPICS PV Access Server listen, then:
 
     EPICS_PVAS_INTF_ADDR_LIST="0.0.0.0"
-
-Metrics
-^^^^^^^
-
-Metrics can be exposed by setting the `management.endpoints.web.exposure.include=prometheus` property. 
-
-.. code-block::
-
-    management.endpoints.web.exposure.include=prometheus, metrics, health, info
-
-Adding the prometheus property will expose the prometheus endpoint which can be scraped by prometheus.
-
-You can also set the metrics.tags to add counts of number of channels per tag. These are exposed as
-`cf_channel_count{tag=tagName}` 
-
-.. code-block::
-
-    metrics.tags=Accelerator, Beamline, Beamline1, Beamline2, Beamline3
-
-You can also set the metrics.properties to add counts of number of channels per property and value. These are exposed as
-`cf_propertyName_channels_count{propertyName=propertyValue}`. 
-
-
-.. code-block::
-
-    metrics.properties=pvStatus:Active, Inactive; archive: default, fast, slow; archiver: aa_beamline, aa_acccelerator

--- a/src/site/sphinx/config.rst
+++ b/src/site/sphinx/config.rst
@@ -163,3 +163,28 @@ Or to not have the EPICS PV Access Server listen, then:
 
     EPICS_PVAS_INTF_ADDR_LIST="0.0.0.0"
 
+Metrics
+^^^^^^^
+
+Metrics can be exposed by setting the `management.endpoints.web.exposure.include=prometheus` property. 
+
+.. code-block::
+
+    management.endpoints.web.exposure.include=prometheus, metrics, health, info
+
+Adding the prometheus property will expose the prometheus endpoint which can be scraped by prometheus.
+
+You can also set the metrics.tags to add counts of number of channels per tag. These are exposed as
+`cf_channel_count{tag=tagName}` 
+
+.. code-block::
+
+    metrics.tags=Accelerator, Beamline, Beamline1, Beamline2, Beamline3
+
+You can also set the metrics.properties to add counts of number of channels per property and value. These are exposed as
+`cf_propertyName_channels_count{propertyName=propertyValue}`. 
+
+
+.. code-block::
+
+    metrics.properties=pvStatus:Active, Inactive; archive: default, fast, slow; archiver: aa_beamline, aa_acccelerator

--- a/src/site/sphinx/index.rst
+++ b/src/site/sphinx/index.rst
@@ -22,3 +22,5 @@ Related projects may be found in the `ChannelFinder <https://github.com/ChannelF
     overview
     config
     api
+    metrics
+    aa_processor

--- a/src/site/sphinx/metrics.rst
+++ b/src/site/sphinx/metrics.rst
@@ -1,0 +1,73 @@
+.. _metrics:
+Metrics
+=======
+
+Metrics can be exposed by setting the `management.endpoints.web.exposure.include=prometheus` property.
+
+.. code-block::
+
+    management.endpoints.web.exposure.include=prometheus, metrics, health, info
+
+Adding the prometheus property will expose the prometheus endpoint which can be scraped by prometheus.
+
+The default metrics exposed by specifying "metrics" are:
+
+.. code-block::
+
+    cf.total.channel.count - Count of all ChannelFinder channels
+    cf.property.count - Count of all Property Names
+    cf.tag.count - Count of all tags
+
+Tag Metrics
+-----------
+
+You can also set the metrics.tags to add counts of number of channels per tag. These are exposed as
+`cf.tag_on_channels.count{tag=tagName}`. For example
+
+.. code-block::
+
+    metrics.tags=Accelerator, Beamline1, Beamline2, Beamline3
+
+Would produce metrics:
+
+.. code-block::
+
+    cf.tag_on_channels.count=109
+    cf.tag_on_channels.count{tag=Accelerator} = 100
+    cf.tag_on_channels.count{tag=Beamline1} = 3
+    cf.tag_on_channels.count{tag=Beamline2} = 3
+    cf.tag_on_channels.count{tag=Beamline3} = 3
+
+Property Metrics
+----------------
+
+You can also set the metrics.properties to add counts of number of channels per property and value. These are exposed as
+`cf_channels_count{prop0=propValueA, prop1=propValueB}`. For example:
+
+
+.. code-block::
+
+    metrics.properties=pvStatus:Active, Inactive; archive: default, !*; archiver: beam, acc, !*
+
+Would produce metrics:
+
+.. code-block::
+
+    cf_channel_count{archive="-",archiver="beam",pvStatus="Inactive",} 0.0
+    cf_channel_count{archive="default",archiver="beam",pvStatus="Inactive",} 0.0
+    cf_channel_count{archive="-",archiver="beam",pvStatus="Active",} 0.0
+    cf_channel_count{archive="-",archiver="-",pvStatus="Active",} 2.0
+    cf_channel_count{archive="default",archiver="acc",pvStatus="Inactive",} 0.0
+    cf_channel_count{archive="-",archiver="acc",pvStatus="Active",} 0.0
+    cf_channel_count{archive="default",archiver="-",pvStatus="Inactive",} 0.0
+    cf_channel_count{archive="default",archiver="-",pvStatus="Active",} 0.0
+    cf_channel_count{archive="default",archiver="beam",pvStatus="Active",} 0.0
+    cf_channel_count{archive="-",archiver="acc",pvStatus="Inactive",} 0.0
+    cf_channel_count{archive="-",archiver="-",pvStatus="Inactive",} 1.0
+    cf_channel_count{archive="default",archiver="acc",pvStatus="Active",} 0.0
+
+Here you can see the value "!*" is special, it does a negation on property name. So for a property name "a", using the
+property value "!*" provides the count of all the channels where the property does not exist.
+
+Note that "!someValue" is also special in that it will search for all the channels where the property is set to
+something other than "someValue".

--- a/src/test/java/org/phoebus/channelfinder/ChannelRepositoryIT.java
+++ b/src/test/java/org/phoebus/channelfinder/ChannelRepositoryIT.java
@@ -258,6 +258,34 @@ class ChannelRepositoryIT {
     }
 
     /**
+     * find channels using not modifier
+     */
+    @Test
+    void findLackOfChannels() {
+        Property extraTestProperty = new Property(testProperties.get(0).getName(), "testOwner", "value2");
+        Channel testChannel = new Channel("testChannel","testOwner",List.of(testProperties.get(0)),testTags);
+        Channel testChannel1 = new Channel("testChannel1","testOwner1",testProperties,testTags);
+        Channel testChannel2 = new Channel("testChannel2","testOwner2",List.of(),List.of());
+        Channel testChannel3 = new Channel("testChannel3","testOwner3",List.of(extraTestProperty),List.of());
+        List<Channel> testChannels = Arrays.asList(testChannel, testChannel1, testChannel2, testChannel3);
+        SearchResult foundChannelsResponse = null;
+
+        List<Channel> createdChannels = channelRepository.indexAll(testChannels);
+        SearchResult createdSearchResult = new SearchResult(createdChannels, 4);
+        cleanupTestChannels = testChannels;
+
+        try {
+            MultiValueMap<String, String> searchParameters = new LinkedMultiValueMap<>();
+            searchParameters.set(testProperties.get(0).getName().toLowerCase() + "!", "*");
+            foundChannelsResponse = channelRepository.search(searchParameters);
+            Assertions.assertEquals(new SearchResult(List.of(createdChannels.get(2)), 1), foundChannelsResponse);
+
+        } catch (ResponseStatusException e) {
+            Assertions.fail(e);
+        }
+    }
+
+    /**
      * find channels using case insensitive names searches
      */
     @Test

--- a/src/test/java/org/phoebus/channelfinder/MetricsServiceIT.java
+++ b/src/test/java/org/phoebus/channelfinder/MetricsServiceIT.java
@@ -36,22 +36,23 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
         locations = "classpath:application_test.properties",
         properties = {
             "metrics.tags=testTag0, testTag1",
-            "metrics.properties={{'testProperty0', 'testProperty0Value'}, {'testProperty1', 'testProperty1Value'}}"
+            "metrics.properties=testProperty0: testProperty0Value; testProperty1: testProperty1Value"
         })
 class MetricsServiceIT {
 
     public static final String METRICS_ENDPOINT = "/actuator/metrics/";
     public static final String METRICS_TAG_LABEL = "tag";
-    public static final String PROPERTY_0_LABEL = "testProperty0:testProperty0Value";
-    public static final String PROPERTY_1_LABEL = "testProperty1:testProperty1Value";
+    public static final String METRICS_PROPERTY_NAME = "testProperty";
+    public static final String PROPERTY_0_LABEL = METRICS_PROPERTY_NAME + "0:testProperty0Value";
+    public static final String PROPERTY_1_LABEL = METRICS_PROPERTY_NAME + "1:testProperty1Value";
     public static final String TAG_0_LABEL = "tag:testTag0";
     public static final String TAG_1_LABEL = "tag:testTag1";
     private final List<Tag> testTags =
             Arrays.asList(new Tag("testTag0", "testTagOwner0"), new Tag("testTag1", "testTagOwner1"));
     private final List<Property> testProperties = Arrays.asList(
-            new Property("testProperty0", "testPropertyOwner0"),
-            new Property("testProperty1", "testPropertyOwner1"),
-            new Property("testProperty2", "testPropertyOwner2"));
+            new Property(METRICS_PROPERTY_NAME + "0", "testPropertyOwner0"),
+            new Property(METRICS_PROPERTY_NAME + "1", "testPropertyOwner1"),
+            new Property(METRICS_PROPERTY_NAME + "2", "testPropertyOwner2"));
 
     @Autowired
     ChannelRepository channelRepository;
@@ -141,10 +142,10 @@ class MetricsServiceIT {
 
     @Test
     void testPropertyMultiGaugeMetrics() throws Exception {
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_CHANNEL_COUNT)
+    mockMvc.perform(get(METRICS_ENDPOINT + String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, METRICS_PROPERTY_NAME + "0"))
                         .param(METRICS_TAG_LABEL, PROPERTY_0_LABEL))
                 .andExpect(jsonPath("$.measurements[0].value").value(0));
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_CHANNEL_COUNT)
+        mockMvc.perform(get(METRICS_ENDPOINT + String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, METRICS_PROPERTY_NAME + "1"))
                         .param(METRICS_TAG_LABEL, PROPERTY_1_LABEL))
                 .andExpect(jsonPath("$.measurements[0].value").value(0));
 
@@ -156,15 +157,15 @@ class MetricsServiceIT {
                 "testOwner",
                 testProperties.stream()
                         .map(p -> new Property(p.getName(), p.getOwner(), p.getName() + "Value"))
-                        .collect(Collectors.toList()),
+                        .toList(),
                 testTags);
         channelRepository.save(testChannel);
 
         await().untilAsserted(() -> {
-            mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_CHANNEL_COUNT)
+            mockMvc.perform(get(METRICS_ENDPOINT + String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, METRICS_PROPERTY_NAME + "0"))
                             .param(METRICS_TAG_LABEL, PROPERTY_0_LABEL))
                     .andExpect(jsonPath("$.measurements[0].value").value(1));
-            mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_CHANNEL_COUNT)
+            mockMvc.perform(get(METRICS_ENDPOINT + String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, METRICS_PROPERTY_NAME + "1"))
                             .param(METRICS_TAG_LABEL, PROPERTY_1_LABEL))
                     .andExpect(jsonPath("$.measurements[0].value").value(1));
         });

--- a/src/test/java/org/phoebus/channelfinder/MetricsServiceIT.java
+++ b/src/test/java/org/phoebus/channelfinder/MetricsServiceIT.java
@@ -19,40 +19,32 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = Application.class)
 @AutoConfigureMockMvc
 @ActiveProfiles("metrics")
 @TestPropertySource(
-        locations = "classpath:application_test.properties",
-        properties = {
-            "metrics.tags=testTag0, testTag1",
-            "metrics.properties=testProperty0: testProperty0Value; testProperty1: testProperty1Value"
-        })
+    locations = "classpath:application_test.properties",
+    properties = {
+        "metrics.tags=testTag0, testTag1",
+        "metrics.properties=testProperty0: value0, value1; testProperty1: value0"
+    })
 class MetricsServiceIT {
 
     public static final String METRICS_ENDPOINT = "/actuator/metrics/";
-    public static final String METRICS_TAG_LABEL = "tag";
-    public static final String METRICS_PROPERTY_NAME = "testProperty";
-    public static final String PROPERTY_0_LABEL = METRICS_PROPERTY_NAME + "0:testProperty0Value";
-    public static final String PROPERTY_1_LABEL = METRICS_PROPERTY_NAME + "1:testProperty1Value";
-    public static final String TAG_0_LABEL = "tag:testTag0";
-    public static final String TAG_1_LABEL = "tag:testTag1";
-    private final List<Tag> testTags =
-            Arrays.asList(new Tag("testTag0", "testTagOwner0"), new Tag("testTag1", "testTagOwner1"));
-    private final List<Property> testProperties = Arrays.asList(
-            new Property(METRICS_PROPERTY_NAME + "0", "testPropertyOwner0"),
-            new Property(METRICS_PROPERTY_NAME + "1", "testPropertyOwner1"),
-            new Property(METRICS_PROPERTY_NAME + "2", "testPropertyOwner2"));
+    public static final String PROPERTY_NAME = "testProperty";
+    public static final String OWNER = "testOwner";
+    public static final String TAG_NAME = "testTag";
+    public static final String METRICS_PARAM_KEY = "tag";
+    public static final String PROPERTY_VALUE = "value";
+
 
     @Autowired
     ChannelRepository channelRepository;
@@ -93,81 +85,119 @@ class MetricsServiceIT {
         tagRepository.findAll().forEach(t -> tagRepository.deleteById(t.getName()));
         propertyRepository.findAll().forEach(p -> propertyRepository.deleteById(p.getName()));
     }
+
+    private void getAndExpectMetric(String paramValue, String endpoint, int expectedValue) throws Exception {
+        mockMvc.perform(get(METRICS_ENDPOINT + endpoint)
+                .param(METRICS_PARAM_KEY, paramValue))
+            .andExpect(jsonPath("$.measurements[0].value").value(expectedValue));
+    }
+
+    private void getAndExpectMetricParent(String endpoint, int expectedValue) throws Exception {
+        mockMvc.perform(get(METRICS_ENDPOINT + endpoint))
+            .andExpect(jsonPath("$.measurements[0].value").value(expectedValue));
+    }
+
     @Test
     void testGaugeMetrics() throws Exception {
         mockMvc.perform(get(METRICS_ENDPOINT)).andExpect(status().is(200));
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_TOTAL_CHANNEL_COUNT))
-                .andExpect(jsonPath("$.measurements[0].value").value(0));
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_PROPERTY_COUNT))
-                .andExpect(jsonPath("$.measurements[0].value").value(0));
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_TAG_COUNT))
-                .andExpect(jsonPath("$.measurements[0].value").value(0));
+        getAndExpectMetricParent(MetricsService.CF_TOTAL_CHANNEL_COUNT, 0);
+        getAndExpectMetricParent(MetricsService.CF_PROPERTY_COUNT, 0);
+        getAndExpectMetricParent(MetricsService.CF_TAG_COUNT, 0);
 
         Channel testChannel = new Channel("testChannel", "testOwner");
         channelRepository.save(testChannel);
-        propertyRepository.saveAll(testProperties);
-        tagRepository.saveAll(testTags);
+        propertyRepository.saveAll(propertyList(3));
+        tagRepository.saveAll(tagList(2));
 
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_TOTAL_CHANNEL_COUNT))
-                .andExpect(jsonPath("$.measurements[0].value").value(1));
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_PROPERTY_COUNT))
-                .andExpect(jsonPath("$.measurements[0].value").value(3));
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_TAG_COUNT))
-                .andExpect(jsonPath("$.measurements[0].value").value(2));
+        getAndExpectMetricParent(MetricsService.CF_TOTAL_CHANNEL_COUNT, 1);
+        getAndExpectMetricParent(MetricsService.CF_PROPERTY_COUNT, 3);
+        getAndExpectMetricParent(MetricsService.CF_TAG_COUNT, 2);
+    }
+
+    private List<Tag> tagList(int count) {
+        return IntStream.range(0, count).mapToObj(i -> new Tag(TAG_NAME + i, OWNER)).toList();
+    }
+
+    private String tagParamValue(Tag tag) {
+        return String.format("tag:%s", tag.getName());
+    }
+
+
+    private void getAndExpectTagMetric(Tag tag, int expectedValue) throws Exception {
+        getAndExpectMetric(tagParamValue(tag), MetricsService.CF_TAG_ON_CHANNELS_COUNT, expectedValue);
     }
 
     @Test
     void testTagMultiGaugeMetrics() throws Exception {
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_CHANNEL_COUNT)
-                        .param(METRICS_TAG_LABEL, TAG_0_LABEL))
-                .andExpect(jsonPath("$.measurements[0].value").value(0));
-        mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_CHANNEL_COUNT)
-                        .param(METRICS_TAG_LABEL, TAG_1_LABEL))
-                .andExpect(jsonPath("$.measurements[0].value").value(0));
+        List<Tag> testTags = tagList(3);
+        getAndExpectMetricParent(MetricsService.CF_TAG_ON_CHANNELS_COUNT, 0);
+        getAndExpectTagMetric(testTags.get(0), 0);
+        getAndExpectTagMetric(testTags.get(1), 0);
 
         tagRepository.saveAll(testTags);
 
         Channel testChannel = new Channel("testChannelTag", "testOwner", List.of(), testTags);
         channelRepository.save(testChannel);
+        Channel testChannel1 = new Channel("testChannelTag1", "testOwner", List.of(), List.of(testTags.get(0)));
+        channelRepository.save(testChannel1);
 
-        await().untilAsserted(() -> {
-            mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_CHANNEL_COUNT)
-                            .param(METRICS_TAG_LABEL, TAG_0_LABEL))
-                    .andExpect(jsonPath("$.measurements[0].value").value(1));
-            mockMvc.perform(get(METRICS_ENDPOINT + MetricsService.CF_CHANNEL_COUNT)
-                            .param(METRICS_TAG_LABEL, TAG_1_LABEL))
-                    .andExpect(jsonPath("$.measurements[0].value").value(1));
-        });
+        getAndExpectTagMetric(testTags.get(0), 2);
+        getAndExpectTagMetric(testTags.get(1), 1);
+        getAndExpectMetricParent(MetricsService.CF_TAG_ON_CHANNELS_COUNT, 3);
+    }
+
+    private List<Property> propertyList(int count) {
+        return IntStream.range(0, count).mapToObj(i -> new Property(PROPERTY_NAME + i, OWNER)).toList();
+    }
+
+    private String propertyParamValue(Property property) {
+        return String.format("%s:%s", property.getName(), property.getValue());
+    }
+
+    private void getAndExpectPropertyMetric(Property property, int expectedValue) throws Exception {
+        getAndExpectMetric(propertyParamValue(property), String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, property.getName()), expectedValue);
+    }
+
+    private void getAndExpectParentPropertyMetric(Property property, int expectedValue) throws Exception {
+        getAndExpectMetricParent(String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, property.getName()), expectedValue);
     }
 
     @Test
     void testPropertyMultiGaugeMetrics() throws Exception {
-    mockMvc.perform(get(METRICS_ENDPOINT + String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, METRICS_PROPERTY_NAME + "0"))
-                        .param(METRICS_TAG_LABEL, PROPERTY_0_LABEL))
-                .andExpect(jsonPath("$.measurements[0].value").value(0));
-        mockMvc.perform(get(METRICS_ENDPOINT + String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, METRICS_PROPERTY_NAME + "1"))
-                        .param(METRICS_TAG_LABEL, PROPERTY_1_LABEL))
-                .andExpect(jsonPath("$.measurements[0].value").value(0));
+        List<Property> testProperties = propertyList(2);
 
+        Channel testChannel = new Channel(
+            "testChannelProp",
+            "testOwner",
+            List.of(
+                new Property(testProperties.get(0).getName(), OWNER, PROPERTY_VALUE + 0),
+                new Property(testProperties.get(1).getName(), OWNER, PROPERTY_VALUE + 0)),
+            List.of());
+
+        Channel testChannel1 = new Channel(
+            "testChannelProp1",
+            "testOwner",
+            List.of(new Property(testProperties.get(0).getName(), OWNER, PROPERTY_VALUE + 1)),
+            List.of());
+
+        getAndExpectParentPropertyMetric(testProperties.get(0), 0);
+        getAndExpectPropertyMetric(testChannel.getProperties().get(0), 0);
+        getAndExpectPropertyMetric(testChannel1.getProperties().get(0), 0);
+
+        getAndExpectParentPropertyMetric(testProperties.get(1), 0);
+        getAndExpectPropertyMetric(testChannel.getProperties().get(1), 0);
 
         propertyRepository.saveAll(testProperties);
 
-        Channel testChannel = new Channel(
-                "testChannelProp",
-                "testOwner",
-                testProperties.stream()
-                        .map(p -> new Property(p.getName(), p.getOwner(), p.getName() + "Value"))
-                        .toList(),
-                testTags);
         channelRepository.save(testChannel);
+        channelRepository.save(testChannel1);
 
-        await().untilAsserted(() -> {
-            mockMvc.perform(get(METRICS_ENDPOINT + String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, METRICS_PROPERTY_NAME + "0"))
-                            .param(METRICS_TAG_LABEL, PROPERTY_0_LABEL))
-                    .andExpect(jsonPath("$.measurements[0].value").value(1));
-            mockMvc.perform(get(METRICS_ENDPOINT + String.format(MetricsService.CF_PROPERTY_FORMAT_STRING, METRICS_PROPERTY_NAME + "1"))
-                            .param(METRICS_TAG_LABEL, PROPERTY_1_LABEL))
-                    .andExpect(jsonPath("$.measurements[0].value").value(1));
-        });
+        getAndExpectParentPropertyMetric(testProperties.get(0), 2);
+        getAndExpectPropertyMetric(testChannel.getProperties().get(0), 1);
+        getAndExpectPropertyMetric(testChannel1.getProperties().get(0), 1);
+
+        getAndExpectParentPropertyMetric(testProperties.get(1), 1);
+        getAndExpectPropertyMetric(testChannel.getProperties().get(1), 1);
+
     }
 }

--- a/src/test/java/org/phoebus/channelfinder/MetricsServiceTest.java
+++ b/src/test/java/org/phoebus/channelfinder/MetricsServiceTest.java
@@ -1,0 +1,91 @@
+package org.phoebus.channelfinder;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MetricsServiceTest {
+
+
+    @Test
+    void testGenerateAllMultiValueMaps_example1() {
+        Map<String, List<String>> properties = Map.of(
+            "a", List.of("b", "c"),
+            "d", List.of("e", "!*")
+        );
+        List<MultiValueMap<String, String>> allMaps = MetricsService.generateAllMultiValueMaps(properties);
+
+        assertEquals(4, allMaps.size());
+
+        assertTrue(allMaps.contains(createMap("a", "b", "d", "e")));
+        assertTrue(allMaps.contains(createMap("a", "c", "d", "e")));
+        assertTrue(allMaps.contains(createMap("a", "b", "d!", "*")));
+        assertTrue(allMaps.contains(createMap("a", "c", "d!", "*")));
+    }
+
+    @Test
+    void testGenerateAllMultiValueMaps_example2() {
+        Map<String, List<String>> properties = Map.of(
+            "x", List.of("y", "z"),
+            "p", List.of("q"),
+            "r", List.of("s", "t")
+        );
+        List<MultiValueMap<String, String>> allMaps = MetricsService.generateAllMultiValueMaps(properties);
+
+        assertEquals(2 * 2, allMaps.size()); // 2 options (value or null) for each of 2 keys
+
+        // Just a basic check, exhaustive check would be large
+        boolean foundExpectedCombination = false;
+        for (MultiValueMap<String, String> map : allMaps) {
+            if (map.get("x").contains("y") && map.get("p").contains("q") && map.get("r").contains("s")) {
+                foundExpectedCombination = true;
+                break;
+            }
+        }
+        assertTrue(foundExpectedCombination);
+    }
+
+    @Test
+    void testGenerateAllMultiValueMaps_emptyList() {
+        Map<String, List<String>> properties = Map.of(
+            "m", List.of()
+        );
+        List<MultiValueMap<String, String>> allMaps = MetricsService.generateAllMultiValueMaps(properties);
+
+        assertEquals(0, allMaps.size()); // One with m=null, one with m implicitly null (not present)
+    }
+
+    @Test
+    void testGenerateAllMultiValueMaps_emptyMap() {
+        Map<String, List<String>> properties = Map.of();
+        List<MultiValueMap<String, String>> allMaps = MetricsService.generateAllMultiValueMaps(properties);
+
+        assertEquals(1, allMaps.size());
+    }
+
+    // Helper method to create a MultiValueMap for easier assertion
+    private MultiValueMap<String, String> createMap(String key1, String value1, String key2, String value2) {
+        LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        if (key1 != null) {
+            map.add(key1, value1);
+        }
+        if (key2 != null) {
+            map.add(key2, value2);
+        }
+        return map;
+    }
+
+    private MultiValueMap<String, String> createMap(String key, String value) {
+        LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        if (key != null) {
+            map.add(key, value);
+        }
+        return map;
+    }
+}

--- a/src/test/resources/application_test.properties
+++ b/src/test/resources/application_test.properties
@@ -107,4 +107,4 @@ aa.auto_pause=pvStatus,archive
 #actuator
 management.endpoints.web.exposure.include=prometheus, metrics, health, info
 metrics.tags=group4_10
-metrics.properties={{'group4', '10'}, {'group5', '10'}}
+metrics.properties=group4: 10; group5: 10


### PR DESCRIPTION
Problem was that on the prometheus list wasn't getting a breakdown of properties more than the first defined one.
Discovered this is due to for each metric (Gauge in micrometer language) every tag has to have a value. So I changed it from 

`cf.channel.count{propertyName=propertyValue}`

to 

`cf.channel.count{prop0=propValueA, prop1=propValueB}` 

and all the many combinations. 

Note: 
From the propertyRepository api, I don't think there is a way to get all of the property values for a property. I think this would be useful, but maybe a big query with the current database design. Can think about this maybe?