### PR TITLE
Timeout and override post support as property values

### DIFF
--- a/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
@@ -197,7 +197,7 @@ public class AAChannelProcessor implements ChannelProcessor {
         if (archivePVS.isEmpty()) {
             return result;
         }
-        List<Map<String, String>> statuses = archiverClient.getStatuses(archivePVS, archiverInfo.url(), archiverInfo.version(), archiverInfo.alias());
+        List<Map<String, String>> statuses = archiverClient.getStatuses(archivePVS, archiverInfo.url(), archiverInfo.alias());
         statuses
                 .forEach(archivePVStatusJsonMap -> {
                     String archiveStatus = archivePVStatusJsonMap.get("status");

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
@@ -7,6 +7,7 @@ import org.phoebus.channelfinder.entity.Property;
 import org.phoebus.channelfinder.processors.ChannelProcessor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,6 +52,7 @@ public class AAChannelProcessor implements ChannelProcessor {
     @Value("${aa.auto_pause:}")
     private List<String> autoPauseOptions;
 
+    @Autowired
     private final ArchiverClient archiverClient = new ArchiverClient();
 
     @Override

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
@@ -197,24 +197,16 @@ public class AAChannelProcessor implements ChannelProcessor {
         if (archivePVS.isEmpty()) {
             return result;
         }
-
-        try {
-            List<Map<String, String>> statuses = archiverClient.getStatuses(archivePVS, archiverInfo.url(), archiverInfo.version(), archiverInfo.alias());
-            statuses
-                    .forEach(archivePVStatusJsonMap -> {
-                        String archiveStatus = archivePVStatusJsonMap.get("status");
-                        String pvName = archivePVStatusJsonMap.get("pvName");
-                        String pvStatus = archivePVS.get(pvName).getPvStatus();
-                        ArchiveAction action = pickArchiveAction(archiveStatus, pvStatus);
-                        result.get(action).add(archivePVS.get(pvName));
-                    });
-            return result;
-
-        } catch (JsonProcessingException e) {
-            // problem collecting policies from AA, so warn and return empty list
-            logger.log(Level.WARNING, () -> "Could not get AA pv Status list: " + e.getMessage());
-            return result;
-        }
+        List<Map<String, String>> statuses = archiverClient.getStatuses(archivePVS, archiverInfo.url(), archiverInfo.version(), archiverInfo.alias());
+        statuses
+                .forEach(archivePVStatusJsonMap -> {
+                    String archiveStatus = archivePVStatusJsonMap.get("status");
+                    String pvName = archivePVStatusJsonMap.get("pvName");
+                    String pvStatus = archivePVS.get(pvName).getPvStatus();
+                    ArchiveAction action = pickArchiveAction(archiveStatus, pvStatus);
+                    result.get(action).add(archivePVS.get(pvName));
+                });
+        return result;
     }
 
     private ArchivePVOptions createArchivePV(

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
@@ -199,7 +199,7 @@ public class AAChannelProcessor implements ChannelProcessor {
         }
 
         try {
-            List<Map<String, String>> statuses = archiverClient.getStatuses(archivePVS, archiverInfo.url(), archiverInfo.version());
+            List<Map<String, String>> statuses = archiverClient.getStatuses(archivePVS, archiverInfo.url(), archiverInfo.version(), archiverInfo.alias());
             statuses
                     .forEach(archivePVStatusJsonMap -> {
                         String archiveStatus = archivePVStatusJsonMap.get("status");

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
@@ -39,7 +39,7 @@ public class ArchiverClient {
 
     @Value("${aa.timeout_seconds:15}")
     private int timeoutSeconds;
-    @Value("${aa.post_support:default}")
+    @Value("${aa.post_support:}")
     private List<String> postSupportArchivers;
 
     private Stream<List<String>> partitionSet(Set<String> pvSet, int pageSize) {
@@ -51,11 +51,14 @@ public class ArchiverClient {
     List<Map<String, String>> getStatuses(Map<String, ArchivePVOptions> archivePVS, String archiverURL, String archiverAlias) {
         Set<String> pvs = archivePVS.keySet();
         Boolean postSupportOverride = postSupportArchivers.contains(archiverAlias);
+        logger.log(Level.INFO, "Archiver Alias: {0}", archiverAlias);
         logger.log(Level.INFO, "Post Support Override Archivers: {0}", postSupportArchivers);
             
         if (Boolean.TRUE.equals(postSupportOverride)) {
+            logger.log(Level.INFO, "Post Support");
             return getStatusesFromPvListBody(archiverURL, pvs.stream().toList());
         } else {
+            logger.log(Level.INFO, "Query Support");
             Stream<List<String>> stream = partitionSet(pvs, STATUS_BATCH_SIZE);
 
             return stream.map(pvList -> getStatusesFromPvListQuery(archiverURL, pvList)).flatMap(List::stream).toList();
@@ -112,7 +115,7 @@ public class ArchiverClient {
         } catch (JsonProcessingException e) {
             logger.log(Level.WARNING, "Could not parse pv status response: " + e.getMessage());
         } catch (Exception e) {
-            logger.log(Level.WARNING, String.format("Error when trying to get status from pv list query: %s", e.getMessage()));
+            logger.log(Level.WARNING, String.format("Error when trying to get status from pv list body: %s", e.getMessage()));
         }
         return List.of();
     }

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
@@ -48,7 +48,7 @@ public class ArchiverClient {
                 .mapToObj(i -> list.subList(i * pageSize, Math.min(pageSize * (i + 1), list.size())));
     }
 
-    List<Map<String, String>> getStatuses(Map<String, ArchivePVOptions> archivePVS, String archiverURL, String archiverVersion, String archiverAlias) {
+    List<Map<String, String>> getStatuses(Map<String, ArchivePVOptions> archivePVS, String archiverURL, String archiverAlias) {
         Set<String> pvs = archivePVS.keySet();
         Boolean querySupportOverride = querySupportOverrideMap.getOrDefault(archiverAlias, false);
         logger.log(Level.INFO, "Query Support Override Map: {0}", querySupportOverrideMap);

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
@@ -68,7 +68,7 @@ public class ArchiverClient {
                 .mapToObj(i -> list.subList(i * pageSize, Math.min(pageSize * (i + 1), list.size())));
     }
 
-    List<Map<String, String>> getStatuses(Map<String, ArchivePVOptions> archivePVS, String archiverURL, String archiverVersion, String archiverAlias) throws JsonProcessingException {
+    List<Map<String, String>> getStatuses(Map<String, ArchivePVOptions> archivePVS, String archiverURL, String archiverVersion, String archiverAlias) {
         Set<String> pvs = archivePVS.keySet();
         Boolean querySupportOverride = querySupportOverrideMap.getOrDefault(archiverAlias, false);
         logger.log(Level.INFO, "Query Support Override Map: {0}", querySupportOverrideMap);

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
@@ -104,8 +104,6 @@ public class ArchiverClient {
                     });
         } catch (JsonProcessingException e) {
             logger.log(Level.WARNING, "Could not parse pv status response: " + e.getMessage());
-        } catch (Exception e) {
-            logger.log(Level.WARNING, String.format("Error when trying to get status from pv list query: %s", e.getMessage()));
         }
         return List.of();
     }
@@ -132,8 +130,6 @@ public class ArchiverClient {
                     });
         } catch (JsonProcessingException e) {
             logger.log(Level.WARNING, "Could not parse pv status response: " + e.getMessage());
-        } catch (Exception e) {
-            logger.log(Level.WARNING, String.format("Error when trying to get status from pv list query: %s", e.getMessage()));
         }
         return List.of();
     }

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
@@ -84,6 +84,8 @@ public class ArchiverClient {
                     });
         } catch (JsonProcessingException e) {
             logger.log(Level.WARNING, "Could not parse pv status response: " + e.getMessage());
+        } catch (Exception e) {
+            logger.log(Level.WARNING, String.format("Error when trying to get status from pv list query: %s", e.getMessage()));
         }
         return List.of();
     }
@@ -110,6 +112,8 @@ public class ArchiverClient {
                     });
         } catch (JsonProcessingException e) {
             logger.log(Level.WARNING, "Could not parse pv status response: " + e.getMessage());
+        } catch (Exception e) {
+            logger.log(Level.WARNING, String.format("Error when trying to get status from pv list query: %s", e.getMessage()));
         }
         return List.of();
     }

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
@@ -71,7 +71,7 @@ public class ArchiverClient {
     List<Map<String, String>> getStatuses(Map<String, ArchivePVOptions> archivePVS, String archiverURL, String archiverVersion, String archiverAlias) throws JsonProcessingException {
         Set<String> pvs = archivePVS.keySet();
         Boolean querySupportOverride = querySupportOverrideMap.getOrDefault(archiverAlias, false);
-        logger.log(Level.INFO, "Query Support Override Map: {0}", querySupportOverrideMap.toString());
+        logger.log(Level.INFO, "Query Support Override Map: {0}", querySupportOverrideMap);
             
         if (AA_STATUS_ENDPOINT_ONLY_SUPPORT_QUERY_VERSION.contains(archiverVersion) || Boolean.TRUE.equals(querySupportOverride)) {
 

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/ArchiverClient.java
@@ -28,26 +28,6 @@ import java.util.stream.Stream;
 public class ArchiverClient {
     private static final Logger logger = Logger.getLogger(ArchiverClient.class.getName());
     private static final int STATUS_BATCH_SIZE = 100; // Limit comes from tomcat server maxHttpHeaderSize which by default is a header of size 8k
-    private static final List<String> AA_STATUS_ENDPOINT_ONLY_SUPPORT_QUERY_VERSION = List.of("1.1.0", 
-            "Before_JDK_12_Upgrade", 
-            "v0.0.1_SNAPSHOT_03-November-2015", 
-            "v0.0.1_SNAPSHOT_09-Oct-2018", 
-            "v0.0.1_SNAPSHOT_10-June-2017", 
-            "v0.0.1_SNAPSHOT_10-Sep-2015", 
-            "v0.0.1_SNAPSHOT_12-May-2016", 
-            "v0.0.1_SNAPSHOT_12-Oct-2016", 
-            "v0.0.1_SNAPSHOT_13-Nov-2019", 
-            "v0.0.1_SNAPSHOT_14-Jun-2018", 
-            "v0.0.1_SNAPSHOT_15-Nov-2018", 
-            "v0.0.1_SNAPSHOT_20-Sept-2016", 
-            "v0.0.1_SNAPSHOT_22-June-2016", 
-            "v0.0.1_SNAPSHOT_22-June-2017", 
-            "v0.0.1_SNAPSHOT_23-Sep-2015", 
-            "v0.0.1_SNAPSHOT_26-January-2016", 
-            "v0.0.1_SNAPSHOT_27-Nov-2017", 
-            "v0.0.1_SNAPSHOT_29-July-2015", 
-            "v0.0.1_SNAPSHOT_30-March-2016", 
-            "v0.0.1_SNAPSHOT_30-September-2021");
 
     private final WebClient client = WebClient.create();
 
@@ -73,7 +53,7 @@ public class ArchiverClient {
         Boolean querySupportOverride = querySupportOverrideMap.getOrDefault(archiverAlias, false);
         logger.log(Level.INFO, "Query Support Override Map: {0}", querySupportOverrideMap);
             
-        if (AA_STATUS_ENDPOINT_ONLY_SUPPORT_QUERY_VERSION.contains(archiverVersion) || Boolean.TRUE.equals(querySupportOverride)) {
+        if (Boolean.TRUE.equals(querySupportOverride)) {
 
             Stream<List<String>> stream = partitionSet(pvs, STATUS_BATCH_SIZE);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -122,8 +122,6 @@ aa.enabled=true
 aa.pva=false
 aa.archive_property_name=archive
 aa.archiver_property_name=archiver
-aa.timeout_seconds=15
-aa.query_support_override_map={'default': true}
 
 # Set the auto pause behaviour
 #

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -122,6 +122,8 @@ aa.enabled=true
 aa.pva=false
 aa.archive_property_name=archive
 aa.archiver_property_name=archiver
+aa.timeout_seconds=15
+aa.query_support_override_map={'default': true}
 
 # Set the auto pause behaviour
 #

--- a/src/site/sphinx/aa_processor.rst
+++ b/src/site/sphinx/aa_processor.rst
@@ -11,10 +11,10 @@ A list of archiver appliance URLs and aliases. ::
 
     aa.urls={'default': 'http://archiver-01.example.com:17665', 'neutron-controls': 'http://archiver-02.example.com:17665'}
 
-By default the listed archivers will get statuses by pv list body. If you are using an older archiver, this may cause data buffer limit exception: limit on max bytes to buffer.
-To set the archivers to use get statuses by pv query (legacy functionality), set the property :ref:`aa.query_support_override_map` to a map of archiver aliases to true. ::
+By default the listed archivers will get statuses by pv query.
+To set the archivers to use get statuses by pv list body, set the property :ref:`aa.post_support` to a comma separated list of archiver aliases. ::
     
-    aa.query_support_override_map={'default': true, 'neutron-controls': true}
+    aa.post_support=default, neutron-controls
 
 To set the choice of default archiver appliance, set the property :ref:`aa.default_alias` to the alias of the default archiver appliance. This setting can also be a comma-separated list if you want multiple default archivers.
 

--- a/src/site/sphinx/aa_processor.rst
+++ b/src/site/sphinx/aa_processor.rst
@@ -11,6 +11,11 @@ A list of archiver appliance URLs and aliases. ::
 
     aa.urls={'default': 'http://archiver-01.example.com:17665', 'neutron-controls': 'http://archiver-02.example.com:17665'}
 
+By default the listed archivers will get statuses by pv list body. If you are using an older archiver, this may cause data buffer limit exception: limit on max bytes to buffer.
+To set the archivers to use get statuses by pv query (legacy functionality), set the property :ref:`aa.query_support_override_map` to a map of archiver aliases to true. ::
+    
+    aa.query_support_override_map={'default': true, 'neutron-controls': true}
+
 To set the choice of default archiver appliance, set the property :ref:`aa.default_alias` to the alias of the default archiver appliance. This setting can also be a comma-separated list if you want multiple default archivers.
 
 To pass the PV as "pva://PVNAME" to the archiver appliance, set the property :ref:`aa.pva` to **true**.

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorMultiArchiverIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorMultiArchiverIT.java
@@ -175,7 +175,7 @@ class AAChannelProcessorMultiArchiverIT {
             }
         });
 
-        long count = aaChannelProcessor.process(channels);
+        aaChannelProcessor.process(channels);
 
         AtomicInteger expectedQueryRequests = new AtomicInteger(1);
         RecordedRequest requestQueryVersion = mockQueryArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorMultiIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorMultiIT.java
@@ -33,7 +33,7 @@ import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.archiveP
 import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.inactiveProperty;
 
 @WebMvcTest(AAChannelProcessor.class)
-@TestPropertySource(locations = "classpath:application_test.properties", properties = "aa.post_support:default")
+@TestPropertySource(value = "classpath:application_test.properties")
 class AAChannelProcessorMultiIT {
 
     public static final String BEING_ARCHIVED = "Being archived";

--- a/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorMultiIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/AAChannelProcessorMultiIT.java
@@ -36,7 +36,7 @@ import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.archiveP
 import static org.phoebus.channelfinder.processors.AAChannelProcessorIT.inactiveProperty;
 
 @WebMvcTest(AAChannelProcessor.class)
-@TestPropertySource(value = "classpath:application_test.properties")
+@TestPropertySource(locations = "classpath:application_test.properties", properties = "aa.post_support:default")
 class AAChannelProcessorMultiIT {
 
     public static final String BEING_ARCHIVED = "Being archived";

--- a/src/test/resources/application_test_multi.properties
+++ b/src/test/resources/application_test_multi.properties
@@ -1,5 +1,4 @@
 ################## ChannelFinder Server ####################
-# ChannelFinder https port
 server.port=8443
 
 # Options support for unsecure http
@@ -7,11 +6,11 @@ server.http.enable=true
 server.http.port=8080
 
 server.ssl.key-store-type=PKCS12
-server.ssl.key-store=classpath:keystore/newcf.p12
+server.ssl.key-store=classpath:keystore/cf.p12
 server.ssl.key-store-password=password
 server.ssl.key-alias=cf
 
-security.require-ssl=false
+security.require-ssl=true
 
 server.compression.enabled=true
 # opt in to content types
@@ -24,16 +23,16 @@ logging.level.org.springframework.web=INFO
 
 ############## LDAP - External ##############
 ldap.enabled = false
-#ldap.urls = ldaps://ldap.cs.nsls2.local/dc=nsls2,dc=bnl,dc=gov
-ldap.urls = ldaps://controlns02.nsls2.bnl.gov/dc=nsls2,dc=bnl,dc=gov
-ldap.user.dn.pattern = uid={0},ou=People,dc=nsls2,dc=bnl,dc=gov
-ldap.groups.search.base = ou=Group,dc=nsls2,dc=bnl,dc=gov
+#ldap.urls = ldaps://controlns02.nsls2.bnl.gov/dc=nsls2,dc=bnl,dc=gov
+ldap.base.dn = dc=nsls2,dc=bnl,dc=gov
+ldap.user.dn.pattern = uid={0},ou=People
+ldap.groups.search.base = ou=Group
 ldap.groups.search.pattern = (memberUid= {1})
 
 ############## LDAP - Embedded ##############
 embedded_ldap.enabled = false
-embedded_ldap.urls = ldap://localhost:8389/dc=cf,dc=local
-embedded_ldap.base.dn = dc=cf,dc=local
+embedded_ldap.urls = ldap://localhost:8389/dc=olog,dc=local
+embedded_ldap.base.dn = dc=olog,dc=local
 embedded_ldap.user.dn.pattern = uid={0},ou=People
 embedded_ldap.groups.search.base = ou=Group
 embedded_ldap.groups.search.pattern = (memberUid= {1})
@@ -41,6 +40,7 @@ spring.ldap.embedded.ldif=classpath:cf.ldif
 spring.ldap.embedded.base-dn=dc=cf,dc=local
 spring.ldap.embedded.port=8389
 spring.ldap.embedded.validation.enabled=false
+
 
 ############## Demo Auth ##############
 # users, pwds, roles - lists of comma-separated values (same length)
@@ -51,17 +51,13 @@ spring.ldap.embedded.validation.enabled=false
 #     demo_auth.roles = role1,role2
 #     demo_auth.roles = role1,role21:role22
 demo_auth.enabled = true
-demo_auth.delimiter.roles = :
-demo_auth.users = admin,user
-demo_auth.pwds = adminPass,userPass
-demo_auth.roles = ADMIN,USER
 
 ############## Group-->Role Mapping ##############
 # Customize group names here
-admin-groups=cf-admins,sys-admins,ADMIN
-channel-groups=cf-channels,USER
-property-groups=cf-properties,USER
-tag-groups=cf-tags,USER
+admin-groups=cf-admins,sys-admins
+channel-groups=cf-channels
+property-groups=cf-properties
+tag-groups=cf-tags
 
 ############################## Elastic Network And HTTP ###############################
 
@@ -69,42 +65,17 @@ tag-groups=cf-tags,USER
 # here must belong to the same Elasticsearch cluster.
 elasticsearch.host_urls=http://localhost:9200
 
-# Old way of configuring the Elasticsearch host. Deprecated in favor of
-# elasticsearch.host_urls.
-elasticsearch.network.host=localhost
-
-# Old way of configuring the Elasticsearch HTTP port. Deprecated in favor of
-# elasticsearch.host_urls.
-elasticsearch.http.port=9200
-
-# Value of the Authorization header that is sent with requests to the
-# Elasticsearch sever. This can be used for authentication using tokens or API
-# keys.
-#
-# For example, for token authentication, set this to ?Bearer abcd1234?, where
-# ?abcd1234? is the token. For API key authentication, set this to the Base64
-# encoded version of the concatenation of the API key ID and the API key
-# secret, separated by a colon. See
-# https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.12/_other_authentication_methods.html
-# for details.
-elasticsearch.authorization.header =
-
-# Username and password for authentication with the Elasticsearch server. This
-# is only used if elasticsearch.authorization.header is not set.
-elasticsearch.authorization.username =
-elasticsearch.authorization.password =
-
 # Elasticsearch index names and types used by channelfinder, ensure that any changes here should be replicated in the mapping_definitions.sh
-elasticsearch.tag.index = cf_tags
-elasticsearch.property.index = cf_properties
-elasticsearch.channel.index = channelfinder
+elasticsearch.tag.index = test_${random.int[1,1000]}_cf_tags
+elasticsearch.property.index = test_${random.int[1,1000]}_cf_properties
+elasticsearch.channel.index = test_${random.int[1,1000]}_channelfinder
 
 # maximum query result size
-# WARNING this property is used to update elastic maxResultWindow size. UPDATE  with care.
+# WARNING this changes the elastic settings. UPDATE  with care.
 elasticsearch.query.size = 10000
 
 # Create the Channel Finder indices if they do not exist
-elasticsearch.create.indices=true
+elasticsearch.create.indices = true
 
 ############################## Service Info ###############################
 # ChannelFinder version as defined in the pom file
@@ -115,17 +86,13 @@ channelfinder.version=@project.version@
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=INFO
 
 ################ Archiver Appliance Configuration Processor #################
-aa.urls={'default': 'http://localhost:17665'}
-# Comma-separated list of archivers to use if archiver_property_name is null
-aa.default_alias=default
+aa.urls={'post': 'http://localhost:17664', 'query': 'http://localhost:17665'}
+aa.default_alias=post, query
 aa.enabled=true
 aa.pva=false
 aa.archive_property_name=archive
 aa.archiver_property_name=archiver
-aa.timeout_seconds=15
-
-# Comma-separated list of archivers to use post support
-aa.post_support=
+aa.post_support=post
 
 # Set the auto pause behaviour
 #
@@ -134,11 +101,11 @@ aa.post_support=
 # Or match archive_property_name to pause on archive_property_name not existing
 # Or both, i.e. aa.auto_pause=pvStatus,archive
 #
-aa.auto_pause=
+aa.auto_pause=pvStatus,archive
 
 
 ############################## Metrics ###############################
 #actuator
 management.endpoints.web.exposure.include=prometheus, metrics, health, info
-metrics.tags=
-metrics.properties=pvStatus:Active, Inactive
+metrics.tags=group4_10
+metrics.properties=group4: 10; group5: 10


### PR DESCRIPTION
Add timeout seconds and query support override as property value for aa.

When testing LBNL ChannelFinder calls to Archiver Appliance were timing out. I'm adding timeout seconds as an aa property value instead of it being hard coded. The default value is 15 seconds.

Adding an override map to AA_STATUS_ENDPOINT_ONLY_SUPPORT_QUERY_VERSION that is settable as an aa property value. At LBNL our archiver versions are set with our make system and are unconventional 
`{"etl_version":"Archiver Appliance Version d3dd9cc-2022-08-08-als_SNAPSHOT_09-August-2023T17-53-53","mgmt_version":"Archiver Appliance Version d3dd9cc-2022-08-08-als_SNAPSHOT_09-August-2023T17-53-53","retrieval_version":"Archiver Appliance Version d3dd9cc-2022-08-08-als_SNAPSHOT_09-August-2023T17-53-53","engine_version":"Archiver Appliance Version d3dd9cc-2022-08-08-als_SNAPSHOT_09-August-2023T17-53-53"}`

This caused ChannelFinder to use getStatusesFromPVLisBody for Archiver Appliance when our Archiver does not support that. This was causing data buffer limit exception limit on max bytes to buffer. 

By setting query_support_override_map you can set the query support override for each archiver.
Example:
`
aa.query_support_override_map={'arch05': true, 'arch03': true, 'arch-ml': true}`

The override value will default to false if the archiver alias name isn't found in the map.