### PR TITLE
add extra logging and skipping over bad pvs

### DIFF
--- a/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
@@ -230,11 +230,7 @@ public class AAChannelProcessor implements ChannelProcessor {
       return result;
     }
     List<Map<String, String>> statuses = archiverClient.getStatuses(archivePVS, archiverInfo.url(), archiverInfo.alias());
-    if (statuses == null) {
-      logger.log(Level.WARNING, "archiverClient.getStatuses returned null");
-      return result;
-    }
-    logger.log(Level.INFO, "Statuses {0}", statuses);
+    logger.log(Level.FINER, "Statuses {0}", statuses);
     statuses.forEach(archivePVStatusJsonMap -> {
       String archiveStatus = archivePVStatusJsonMap.get("status");
       String pvName = archivePVStatusJsonMap.get("pvName");

--- a/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessor.java
@@ -250,10 +250,6 @@ public class AAChannelProcessor implements ChannelProcessor {
       ArchiveAction action = pickArchiveAction(archiveStatus, pvStatus);
 
       List<ArchivePVOptions> archivePVOptionsList = result.get(action);
-      if (archivePVOptionsList == null) {
-        logger.log(Level.WARNING, "No list found for action: {0}", action);
-        return;
-      }
       archivePVOptionsList.add(archivePVOptions);
     });
     return result;


### PR DESCRIPTION
channelfinder would break with a null runtime exception here. I've added logging and allowed channelfinder to skip over bad pvs instead of breaking.

For example, we were seeing problems populating a new archiver with channel finder and couldn't figure out why it wouldn't work with a specific ioc (it would break with null runtime exception). I added this and figured out that channelfinder was having problems archiving pvs with commas. It looks like it is splitting the pvs with commas causing channelfinder to break when getting the actions for those pvs.

Overall, functionality to fix pvs with commas still needs to be fixed but for now this lets channel finder catch bad pvs and skip over them instead of breaking.

Example:
BTS_____Q6,1___BM02:AtInjection
`Aug 19 10:39:13 controls-hlc1.als.lbl.gov java[2889]: 2025-08-19 10:39:13.474  WARN 2889 --- [taskExecutor-89] o.p.c.processors.aa.AAChannelProcessor   : archivePVS does not contain pvName: BTS_____Q6
Aug 19 10:39:13 controls-hlc1.als.lbl.gov java[2889]: 2025-08-19 10:39:13.474  WARN 2889 --- [taskExecutor-89] o.p.c.processors.aa.AAChannelProcessor   : archivePVS does not contain pvName: 1___BM02:AtInjection`