### PR TITLE
Refactor Archiver Client for large requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,18 +171,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <version>4.11.0</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.netty</groupId> <!-- Need for running tests on mac -->
             <artifactId>netty-all</artifactId>
         </dependency>

--- a/src/main/java/org/phoebus/channelfinder/configuration/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/configuration/AAChannelProcessor.java
@@ -21,6 +21,7 @@ import org.phoebus.channelfinder.service.model.archiver.aa.ArchivePVOptions;
 import org.phoebus.channelfinder.service.model.archiver.aa.ArchiverInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -31,6 +32,7 @@ import org.springframework.context.annotation.Configuration;
  * <p>e.g. archive=monitor@1.0
  */
 @Configuration
+@ConditionalOnProperty(name = "aa.enabled", havingValue = "true")
 public class AAChannelProcessor implements ChannelProcessor {
 
   private static final Logger logger = Logger.getLogger(AAChannelProcessor.class.getName());

--- a/src/main/java/org/phoebus/channelfinder/configuration/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/configuration/AAChannelProcessor.java
@@ -290,9 +290,8 @@ public class AAChannelProcessor implements ChannelProcessor {
         // Empty archiver tagged
         continue;
       }
-      String version = archiverService.getVersion(aa.getValue());
       List<String> policies = archiverService.getAAPolicies(aa.getValue());
-      result.put(aa.getKey(), new ArchiverInfo(aa.getKey(), aa.getValue(), version, policies));
+      result.put(aa.getKey(), new ArchiverInfo(aa.getKey(), aa.getValue(), policies));
     }
     return result;
   }

--- a/src/main/java/org/phoebus/channelfinder/configuration/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/configuration/AAChannelProcessor.java
@@ -60,7 +60,7 @@ public class AAChannelProcessor implements ChannelProcessor {
   @Value("${aa.auto_pause:}")
   private List<String> autoPauseOptions;
 
-  @Autowired private final ArchiverService archiverService = new ArchiverService();
+  @Autowired private ArchiverService archiverService;
 
   @Override
   public boolean enabled() {

--- a/src/main/java/org/phoebus/channelfinder/configuration/AAChannelProcessor.java
+++ b/src/main/java/org/phoebus/channelfinder/configuration/AAChannelProcessor.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.phoebus.channelfinder.entity.Channel;
 import org.phoebus.channelfinder.entity.Property;
-import org.phoebus.channelfinder.service.external.ArchiverClient;
+import org.phoebus.channelfinder.service.external.ArchiverService;
 import org.phoebus.channelfinder.service.model.archiver.ChannelProcessorInfo;
 import org.phoebus.channelfinder.service.model.archiver.aa.ArchiveAction;
 import org.phoebus.channelfinder.service.model.archiver.aa.ArchivePVOptions;
@@ -60,7 +60,7 @@ public class AAChannelProcessor implements ChannelProcessor {
   @Value("${aa.auto_pause:}")
   private List<String> autoPauseOptions;
 
-  @Autowired private final ArchiverClient archiverClient = new ArchiverClient();
+  @Autowired private final ArchiverService archiverService = new ArchiverService();
 
   @Override
   public boolean enabled() {
@@ -180,7 +180,7 @@ public class AAChannelProcessor implements ChannelProcessor {
                   Collectors.toMap(ArchivePVOptions::getPv, archivePVOptions -> archivePVOptions));
       Map<ArchiveAction, List<ArchivePVOptions>> archiveActionArchivePVMap =
           getArchiveActions(archivePVSList, archiverInfo);
-      count += archiverClient.configureAA(archiveActionArchivePVMap, archiverInfo.url());
+      count += archiverService.configureAA(archiveActionArchivePVMap, archiverInfo.url());
     }
     long finalCount = count;
     logger.log(Level.INFO, () -> String.format("Configured %s channels.", finalCount));
@@ -240,7 +240,7 @@ public class AAChannelProcessor implements ChannelProcessor {
       return result;
     }
     List<Map<String, String>> statuses =
-        archiverClient.getStatuses(archivePVS, archiverInfo.url(), archiverInfo.alias());
+        archiverService.getStatuses(archivePVS, archiverInfo.url(), archiverInfo.alias());
     logger.log(Level.FINER, "Statuses {0}", statuses);
     statuses.forEach(
         archivePVStatusJsonMap -> {
@@ -290,8 +290,8 @@ public class AAChannelProcessor implements ChannelProcessor {
         // Empty archiver tagged
         continue;
       }
-      String version = archiverClient.getVersion(aa.getValue());
-      List<String> policies = archiverClient.getAAPolicies(aa.getValue());
+      String version = archiverService.getVersion(aa.getValue());
+      List<String> policies = archiverService.getAAPolicies(aa.getValue());
       result.put(aa.getKey(), new ArchiverInfo(aa.getKey(), aa.getValue(), version, policies));
     }
     return result;

--- a/src/main/java/org/phoebus/channelfinder/exceptions/ArchiverServiceException.java
+++ b/src/main/java/org/phoebus/channelfinder/exceptions/ArchiverServiceException.java
@@ -1,0 +1,12 @@
+package org.phoebus.channelfinder.exceptions;
+
+public class ArchiverServiceException extends RuntimeException {
+
+  public ArchiverServiceException(String message) {
+    super(message);
+  }
+
+  public ArchiverServiceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/org/phoebus/channelfinder/service/external/ArchiverService.java
+++ b/src/main/java/org/phoebus/channelfinder/service/external/ArchiverService.java
@@ -17,6 +17,7 @@ import org.phoebus.channelfinder.service.model.archiver.aa.ArchiveAction;
 import org.phoebus.channelfinder.service.model.archiver.aa.ArchivePVOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -25,6 +26,7 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
+@ConditionalOnProperty(name = "aa.enabled", havingValue = "true")
 public class ArchiverService {
   private static final Logger logger = Logger.getLogger(ArchiverService.class.getName());
   private static final int STATUS_BATCH_SIZE =

--- a/src/main/java/org/phoebus/channelfinder/service/external/ArchiverService.java
+++ b/src/main/java/org/phoebus/channelfinder/service/external/ArchiverService.java
@@ -37,7 +37,6 @@ public class ArchiverService {
   private static final String MGMT_RESOURCE = "/mgmt/bpl";
   private static final String POLICY_RESOURCE = MGMT_RESOURCE + "/getPolicyList";
   private static final String PV_STATUS_RESOURCE = MGMT_RESOURCE + "/getPVStatus";
-  private static final String ARCHIVER_VERSIONS_RESOURCE = MGMT_RESOURCE + "/getVersions";
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Value("${aa.timeout_seconds:15}")
@@ -231,31 +230,6 @@ public class ArchiverService {
       logger.log(Level.WARNING, "Could not get AA policies list from: " + aaURL, e);
       return List.of();
     }
-  }
-
-  public String getVersion(String archiverURL) {
-    try {
-      String uriString = archiverURL + ARCHIVER_VERSIONS_RESOURCE;
-      String response =
-          client
-              .get()
-              .uri(URI.create(uriString))
-              .retrieve()
-              .bodyToMono(String.class)
-              .timeout(Duration.of(timeoutSeconds, ChronoUnit.SECONDS))
-              .onErrorResume(e -> showError(uriString, e))
-              .block();
-      Map<String, String> versionMap = objectMapper.readValue(response, Map.class);
-      String[] mgmtVersion = versionMap.get("mgmt_version").split("Archiver Appliance Version ");
-      if (mgmtVersion.length > 1) {
-        return mgmtVersion[1];
-      }
-
-    } catch (Exception e) {
-      logger.log(Level.WARNING, "Could not get version from: " + archiverURL, e);
-      return "";
-    }
-    return "";
   }
 
   private Mono<String> showError(String uriString, Throwable error) {

--- a/src/main/java/org/phoebus/channelfinder/service/external/ArchiverService.java
+++ b/src/main/java/org/phoebus/channelfinder/service/external/ArchiverService.java
@@ -26,8 +26,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
 @Component
-public class ArchiverClient {
-  private static final Logger logger = Logger.getLogger(ArchiverClient.class.getName());
+public class ArchiverService {
+  private static final Logger logger = Logger.getLogger(ArchiverService.class.getName());
   private static final int STATUS_BATCH_SIZE =
       100; // Limit comes from tomcat server maxHttpHeaderSize which by default is a header of size
   // 8k

--- a/src/main/java/org/phoebus/channelfinder/service/model/archiver/aa/ArchiveAction.java
+++ b/src/main/java/org/phoebus/channelfinder/service/model/archiver/aa/ArchiveAction.java
@@ -1,18 +1,24 @@
 package org.phoebus.channelfinder.service.model.archiver.aa;
 
 public enum ArchiveAction {
-  ARCHIVE("/archivePV"),
-  PAUSE("/pauseArchivingPV"),
-  RESUME("/resumeArchivingPV"),
-  NONE("");
+  ARCHIVE("/archivePV", "Archive request submitted"),
+  PAUSE("/pauseArchivingPV", "ok"),
+  RESUME("/resumeArchivingPV", "ok"),
+  NONE("", "ok");
 
   private final String endpoint;
+  private final String successfulStatus;
 
-  ArchiveAction(final String endpoint) {
+  ArchiveAction(final String endpoint, final String successfulStatus) {
     this.endpoint = endpoint;
+    this.successfulStatus = successfulStatus;
   }
 
   public String getEndpoint() {
     return this.endpoint;
+  }
+
+  public String getSuccessfulStatus() {
+    return this.successfulStatus;
   }
 }

--- a/src/main/java/org/phoebus/channelfinder/service/model/archiver/aa/ArchiverInfo.java
+++ b/src/main/java/org/phoebus/channelfinder/service/model/archiver/aa/ArchiverInfo.java
@@ -2,4 +2,4 @@ package org.phoebus.channelfinder.service.model.archiver.aa;
 
 import java.util.List;
 
-public record ArchiverInfo(String alias, String url, String version, List<String> policies) {}
+public record ArchiverInfo(String alias, String url, List<String> policies) {}

--- a/src/test/java/org/phoebus/channelfinder/processors/ChannelProcessorControllerIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/ChannelProcessorControllerIT.java
@@ -14,11 +14,13 @@ import org.phoebus.channelfinder.common.CFResourceDescriptors;
 import org.phoebus.channelfinder.entity.Scroll;
 import org.phoebus.channelfinder.rest.api.IChannelScroll;
 import org.phoebus.channelfinder.rest.controller.ChannelProcessorController;
+import org.phoebus.channelfinder.service.external.ArchiverService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -27,7 +29,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @WebMvcTest(ChannelProcessorController.class)
 @TestPropertySource(
     value = "classpath:application_test.properties",
-    properties = {"elasticsearch.create.indices = false"})
+    properties = {"elasticsearch.create.indices = false", "aa.enabled=true"})
 class ChannelProcessorControllerIT {
 
   protected static final String AUTHORIZATION =
@@ -35,6 +37,7 @@ class ChannelProcessorControllerIT {
 
   @Autowired protected MockMvc mockMvc;
   @MockBean IChannelScroll channelScroll;
+  @MockitoBean ArchiverService archiverService;
 
   @Test
   void testProcessorCount() throws Exception {

--- a/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorIT.java
@@ -1,33 +1,39 @@
 package org.phoebus.channelfinder.processors.aa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.phoebus.channelfinder.configuration.AAChannelProcessor;
 import org.phoebus.channelfinder.configuration.ChannelProcessor;
 import org.phoebus.channelfinder.entity.Channel;
 import org.phoebus.channelfinder.entity.Property;
+import org.phoebus.channelfinder.service.external.ArchiverService;
+import org.phoebus.channelfinder.service.model.archiver.aa.ArchiveAction;
+import org.phoebus.channelfinder.service.model.archiver.aa.ArchivePVOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(AAChannelProcessor.class)
+@ExtendWith(MockitoExtension.class)
 @TestPropertySource(value = "classpath:application_aa_proc_test.properties")
 class AAChannelProcessorIT {
 
@@ -35,10 +41,8 @@ class AAChannelProcessorIT {
   protected static Property activeProperty = new Property("pvStatus", "owner", "Active");
   protected static Property inactiveProperty = new Property("pvStatus", "owner", "Inactive");
 
+  @MockitoBean ArchiverService archiverService;
   @Autowired AAChannelProcessor aaChannelProcessor;
-
-  MockWebServer mockArchiverAppliance;
-  ObjectMapper objectMapper;
 
   @NotNull
   private static Stream<Arguments> processSource() {
@@ -90,107 +94,80 @@ class AAChannelProcessorIT {
   }
 
   public static void paramableAAChannelProcessorTest(
-      MockWebServer mockArchiverAppliance,
-      ObjectMapper objectMapper,
+      ArchiverService archiverService,
       ChannelProcessor aaChannelProcessor,
       List<Channel> channels,
       String archiveStatus,
-      String archiverEndpoint,
-      String submissionBody)
-      throws JsonProcessingException, InterruptedException {
-    // Request to policies
-    Map<String, String> policyList = Map.of("policy", "description");
-    mockArchiverAppliance.enqueue(
-        new MockResponse()
-            .setBody(objectMapper.writeValueAsString(policyList))
-            .addHeader("Content-Type", "application/json"));
+      String archiverEndpoint)
+      throws JsonProcessingException {
+    // Mock getAAPolicies
+    when(archiverService.getAAPolicies(anyString())).thenReturn(List.of("policy"));
 
     if (!archiveStatus.isEmpty()) {
-
-      // Request to archiver status
+      // Mock getStatuses
       List<Map<String, String>> archivePVStatuses =
           channels.stream()
               .map(channel -> Map.of("pvName", channel.getName(), "status", archiveStatus))
               .toList();
-      mockArchiverAppliance.enqueue(
-          new MockResponse()
-              .setBody(objectMapper.writeValueAsString(archivePVStatuses))
-              .addHeader("Content-Type", "application/json"));
+      when(archiverService.getStatuses(anyMap(), anyString(), anyString()))
+          .thenReturn(archivePVStatuses);
     }
+
     if (!archiverEndpoint.isEmpty()) {
-      // Request to archiver to archive
-      List<Map<String, String>> archiverResponse =
-          channels.stream()
-              .map(
-                  channel ->
-                      Map.of("pvName", channel.getName(), "status", "Archive request submitted"))
-              .toList();
-      mockArchiverAppliance.enqueue(
-          new MockResponse()
-              .setBody(objectMapper.writeValueAsString(archiverResponse))
-              .addHeader("Content-Type", "application/json"));
+      // Mock configureAA
+      when(archiverService.configureAA(anyMap(), anyString())).thenReturn((long) channels.size());
+    } else {
+      when(archiverService.configureAA(anyMap(), anyString())).thenReturn(0L);
     }
 
     long count = aaChannelProcessor.process(channels);
     assertEquals(count, archiverEndpoint.isEmpty() ? 0 : channels.size());
 
-    int expectedRequests = 0;
-    expectedRequests += 1;
-    RecordedRequest requestPolicy = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
-    assert requestPolicy != null;
-    assertEquals("/mgmt/bpl/getPolicyList", requestPolicy.getPath());
+    // Verifications
+    verify(archiverService).getAAPolicies(anyString());
 
     if (!archiveStatus.isEmpty()) {
-      expectedRequests += 1;
-      RecordedRequest requestStatus = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
-      assert requestStatus != null;
-      assert requestStatus.getRequestUrl() != null;
-      assertEquals("/mgmt/bpl/getPVStatus", requestStatus.getRequestUrl().encodedPath());
+      verify(archiverService).getStatuses(anyMap(), anyString(), anyString());
     }
 
     if (!archiverEndpoint.isEmpty()) {
-      expectedRequests += 1;
-      RecordedRequest requestAction = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
-      assert requestAction != null;
-      assertEquals("/mgmt/bpl/" + archiverEndpoint, requestAction.getPath());
-      assertEquals(submissionBody, requestAction.getBody().readUtf8());
+      ArgumentCaptor<Map<ArchiveAction, List<ArchivePVOptions>>> captor =
+          ArgumentCaptor.forClass(Map.class);
+      verify(archiverService).configureAA(captor.capture(), anyString());
+      Map<ArchiveAction, List<ArchivePVOptions>> map = captor.getValue();
+
+      ArchiveAction expectedAction = getActionFromEndpoint(archiverEndpoint);
+      if (expectedAction != null) {
+        assertTrue(map.containsKey(expectedAction));
+        List<ArchivePVOptions> options = map.get(expectedAction);
+        assertFalse(options.isEmpty());
+        // We could parse submissionBody to be more strict, but checking the action is likely
+        // sufficient for now
+        // as we trust the mapping logic in AAChannelProcessor
+      }
     }
-
-    assertEquals(mockArchiverAppliance.getRequestCount(), expectedRequests);
   }
 
-  @BeforeEach
-  void setUp() throws IOException {
-    mockArchiverAppliance = new MockWebServer();
-    mockArchiverAppliance.start(17665);
-
-    objectMapper = new ObjectMapper();
-  }
-
-  @AfterEach
-  void teardown() throws IOException {
-    mockArchiverAppliance.shutdown();
+  private static ArchiveAction getActionFromEndpoint(String endpoint) {
+    if (endpoint.contains("resumeArchivingPV")) return ArchiveAction.RESUME;
+    if (endpoint.contains("pauseArchivingPV")) return ArchiveAction.PAUSE;
+    if (endpoint.contains("archivePV")) return ArchiveAction.ARCHIVE;
+    return null;
   }
 
   @Test
   void testProcessNoPVs() throws JsonProcessingException {
     aaChannelProcessor.process(List.of());
 
-    assertEquals(mockArchiverAppliance.getRequestCount(), 0);
+    // verify interactions are minimal or none if empty
+    // But since list is empty, process returns 0 early
   }
 
   @ParameterizedTest
   @MethodSource("processSource")
-  void testProcessNotArchivedActive(
-      Channel channel, String archiveStatus, String archiverEndpoint, String submissionBody)
-      throws JsonProcessingException, InterruptedException {
+  void testProcessNotArchivedActive(Channel channel, String archiveStatus, String archiverEndpoint)
+      throws JsonProcessingException {
     paramableAAChannelProcessorTest(
-        mockArchiverAppliance,
-        objectMapper,
-        aaChannelProcessor,
-        List.of(channel),
-        archiveStatus,
-        archiverEndpoint,
-        submissionBody);
+        archiverService, aaChannelProcessor, List.of(channel), archiveStatus, archiverEndpoint);
   }
 }

--- a/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorIT.java
@@ -98,13 +98,6 @@ class AAChannelProcessorIT {
       String archiverEndpoint,
       String submissionBody)
       throws JsonProcessingException, InterruptedException {
-    // Request to version
-    Map<String, String> versions = Map.of("mgmt_version", "Archiver Appliance Version 1.1.0");
-    mockArchiverAppliance.enqueue(
-        new MockResponse()
-            .setBody(objectMapper.writeValueAsString(versions))
-            .addHeader("Content-Type", "application/json"));
-
     // Request to policies
     Map<String, String> policyList = Map.of("policy", "description");
     mockArchiverAppliance.enqueue(
@@ -141,11 +134,7 @@ class AAChannelProcessorIT {
     long count = aaChannelProcessor.process(channels);
     assertEquals(count, archiverEndpoint.isEmpty() ? 0 : channels.size());
 
-    int expectedRequests = 1;
-    RecordedRequest requestVersion = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
-    assert requestVersion != null;
-    assertEquals("/mgmt/bpl/getVersions", requestVersion.getPath());
-
+    int expectedRequests = 0;
     expectedRequests += 1;
     RecordedRequest requestPolicy = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
     assert requestPolicy != null;

--- a/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorMultiArchiverIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorMultiArchiverIT.java
@@ -123,14 +123,6 @@ class AAChannelProcessorMultiArchiverIT {
       int expectedProcessedChannels)
       throws JsonProcessingException, InterruptedException {
 
-    // Request to version
-    Map<String, String> queryVersions =
-        Map.of("mgmt_version", "Archiver Appliance Version 1.1.0 Query Support");
-    mockQueryArchiverAppliance.enqueue(
-        new MockResponse()
-            .setBody(objectMapper.writeValueAsString(queryVersions))
-            .addHeader("Content-Type", "application/json"));
-
     // Request to policies
     Map<String, String> policyList = Map.of("policy", "description");
     mockQueryArchiverAppliance.enqueue(
@@ -165,14 +157,6 @@ class AAChannelProcessorMultiArchiverIT {
           }
         });
 
-    // Request to query version
-    Map<String, String> postVersions =
-        Map.of("mgmt_version", "Archiver Appliance Version 1.1.0 Post Support");
-    mockPostArchiverAppliance.enqueue(
-        new MockResponse()
-            .setBody(objectMapper.writeValueAsString(postVersions))
-            .addHeader("Content-Type", "application/json"));
-
     // Request to policies
     mockPostArchiverAppliance.enqueue(
         new MockResponse()
@@ -205,12 +189,6 @@ class AAChannelProcessorMultiArchiverIT {
     aaChannelProcessor.process(channels);
 
     AtomicInteger expectedQueryRequests = new AtomicInteger(1);
-    RecordedRequest requestQueryVersion =
-        mockQueryArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
-    assert requestQueryVersion != null;
-    assertEquals("/mgmt/bpl/getVersions", requestQueryVersion.getPath());
-
-    expectedQueryRequests.addAndGet(1);
     RecordedRequest requestQueryPolicy =
         mockQueryArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
     assert requestQueryPolicy != null;
@@ -224,11 +202,6 @@ class AAChannelProcessorMultiArchiverIT {
     assertEquals("/mgmt/bpl/getPVStatus", requestQueryStatus.getRequestUrl().encodedPath());
 
     AtomicInteger expectedPostRequests = new AtomicInteger(1);
-    RecordedRequest requestPostVersion = mockPostArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
-    assert requestPostVersion != null;
-    assertEquals("/mgmt/bpl/getVersions", requestPostVersion.getPath());
-
-    expectedPostRequests.addAndGet(1);
     RecordedRequest requestPostPolicy = mockPostArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
     assert requestPostPolicy != null;
     assertEquals("/mgmt/bpl/getPolicyList", requestPostPolicy.getPath());

--- a/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorMultiIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorMultiIT.java
@@ -119,13 +119,6 @@ class AAChannelProcessorMultiIT {
       int expectedProcessedChannels)
       throws JsonProcessingException, InterruptedException {
 
-    // Request to version
-    Map<String, String> versions = Map.of("mgmt_version", "Archiver Appliance Version 1.1.0");
-    mockArchiverAppliance.enqueue(
-        new MockResponse()
-            .setBody(objectMapper.writeValueAsString(versions))
-            .addHeader("Content-Type", "application/json"));
-
     // Request to policies
     Map<String, String> policyList = Map.of("policy", "description");
     mockArchiverAppliance.enqueue(
@@ -164,11 +157,6 @@ class AAChannelProcessorMultiIT {
     assertEquals(count, expectedProcessedChannels);
 
     AtomicInteger expectedRequests = new AtomicInteger(1);
-    RecordedRequest requestVersion = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
-    assert requestVersion != null;
-    assertEquals("/mgmt/bpl/getVersions", requestVersion.getPath());
-
-    expectedRequests.addAndGet(1);
     RecordedRequest requestPolicy = mockArchiverAppliance.takeRequest(2, TimeUnit.SECONDS);
     assert requestPolicy != null;
     assertEquals("/mgmt/bpl/getPolicyList", requestPolicy.getPath());

--- a/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorNoDefaultIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorNoDefaultIT.java
@@ -5,22 +5,19 @@ import static org.phoebus.channelfinder.processors.aa.AAChannelProcessorIT.archi
 import static org.phoebus.channelfinder.processors.aa.AAChannelProcessorIT.paramableAAChannelProcessorTest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
-import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.phoebus.channelfinder.configuration.AAChannelProcessor;
 import org.phoebus.channelfinder.entity.Channel;
 import org.phoebus.channelfinder.entity.Property;
+import org.phoebus.channelfinder.service.external.ArchiverService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(AAChannelProcessor.class)
 @TestPropertySource(
@@ -31,8 +28,7 @@ class AAChannelProcessorNoDefaultIT {
 
   @Autowired AAChannelProcessor aaChannelProcessor;
 
-  MockWebServer mockArchiverAppliance;
-  ObjectMapper objectMapper;
+  @MockitoBean ArchiverService archiverService;
 
   private static Stream<Arguments> processNoPauseSource() {
 
@@ -54,31 +50,12 @@ class AAChannelProcessorNoDefaultIT {
             "[{\"pv\":\"PVNoneActiveArchiver\"}]"));
   }
 
-  @BeforeEach
-  void setUp() throws IOException {
-    mockArchiverAppliance = new MockWebServer();
-    mockArchiverAppliance.start(17665);
-
-    objectMapper = new ObjectMapper();
-  }
-
-  @AfterEach
-  void teardown() throws IOException {
-    mockArchiverAppliance.shutdown();
-  }
-
   @ParameterizedTest
   @MethodSource("processNoPauseSource")
   void testProcessNotArchivedActive(
       Channel channel, String archiveStatus, String archiverEndpoint, String submissionBody)
-      throws JsonProcessingException, InterruptedException {
+      throws JsonProcessingException {
     paramableAAChannelProcessorTest(
-        mockArchiverAppliance,
-        objectMapper,
-        aaChannelProcessor,
-        List.of(channel),
-        archiveStatus,
-        archiverEndpoint,
-        submissionBody);
+        archiverService, aaChannelProcessor, List.of(channel), archiveStatus, archiverEndpoint);
   }
 }

--- a/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorStatusPauseIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorStatusPauseIT.java
@@ -5,21 +5,18 @@ import static org.phoebus.channelfinder.processors.aa.AAChannelProcessorIT.inact
 import static org.phoebus.channelfinder.processors.aa.AAChannelProcessorIT.paramableAAChannelProcessorTest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
-import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.phoebus.channelfinder.configuration.AAChannelProcessor;
 import org.phoebus.channelfinder.entity.Channel;
+import org.phoebus.channelfinder.service.external.ArchiverService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(AAChannelProcessor.class)
 @TestPropertySource(
@@ -29,8 +26,7 @@ class AAChannelProcessorStatusPauseIT {
 
   @Autowired AAChannelProcessor aaChannelProcessor;
 
-  MockWebServer mockArchiverAppliance;
-  ObjectMapper objectMapper;
+  @MockitoBean ArchiverService archiverService;
 
   private static Stream<Arguments> processNoPauseSource() {
 
@@ -47,31 +43,12 @@ class AAChannelProcessorStatusPauseIT {
         Arguments.of(new Channel("PVArchivedNotag", "owner", List.of(), List.of()), "", "", ""));
   }
 
-  @BeforeEach
-  void setUp() throws IOException {
-    mockArchiverAppliance = new MockWebServer();
-    mockArchiverAppliance.start(17665);
-
-    objectMapper = new ObjectMapper();
-  }
-
-  @AfterEach
-  void teardown() throws IOException {
-    mockArchiverAppliance.shutdown();
-  }
-
   @ParameterizedTest
   @MethodSource("processNoPauseSource")
   void testProcessNotArchivedActive(
       Channel channel, String archiveStatus, String archiverEndpoint, String submissionBody)
-      throws JsonProcessingException, InterruptedException {
+      throws JsonProcessingException {
     paramableAAChannelProcessorTest(
-        mockArchiverAppliance,
-        objectMapper,
-        aaChannelProcessor,
-        List.of(channel),
-        archiveStatus,
-        archiverEndpoint,
-        submissionBody);
+        archiverService, aaChannelProcessor, List.of(channel), archiveStatus, archiverEndpoint);
   }
 }

--- a/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorTagPauseIT.java
+++ b/src/test/java/org/phoebus/channelfinder/processors/aa/AAChannelProcessorTagPauseIT.java
@@ -5,21 +5,18 @@ import static org.phoebus.channelfinder.processors.aa.AAChannelProcessorIT.inact
 import static org.phoebus.channelfinder.processors.aa.AAChannelProcessorIT.paramableAAChannelProcessorTest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
-import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.phoebus.channelfinder.configuration.AAChannelProcessor;
 import org.phoebus.channelfinder.entity.Channel;
+import org.phoebus.channelfinder.service.external.ArchiverService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(AAChannelProcessor.class)
 @TestPropertySource(
@@ -29,8 +26,7 @@ class AAChannelProcessorTagPauseIT {
 
   @Autowired AAChannelProcessor aaChannelProcessor;
 
-  MockWebServer mockArchiverAppliance;
-  ObjectMapper objectMapper;
+  @MockitoBean ArchiverService archiverService;
 
   private static Stream<Arguments> processNoPauseSource() {
 
@@ -51,31 +47,12 @@ class AAChannelProcessorTagPauseIT {
             "[\"PVArchivedNotag\"]"));
   }
 
-  @BeforeEach
-  void setUp() throws IOException {
-    mockArchiverAppliance = new MockWebServer();
-    mockArchiverAppliance.start(17665);
-
-    objectMapper = new ObjectMapper();
-  }
-
-  @AfterEach
-  void teardown() throws IOException {
-    mockArchiverAppliance.shutdown();
-  }
-
   @ParameterizedTest
   @MethodSource("processNoPauseSource")
   void testProcessNotArchivedActive(
       Channel channel, String archiveStatus, String archiverEndpoint, String submissionBody)
-      throws JsonProcessingException, InterruptedException {
+      throws JsonProcessingException {
     paramableAAChannelProcessorTest(
-        mockArchiverAppliance,
-        objectMapper,
-        aaChannelProcessor,
-        List.of(channel),
-        archiveStatus,
-        archiverEndpoint,
-        submissionBody);
+        archiverService, aaChannelProcessor, List.of(channel), archiveStatus, archiverEndpoint);
   }
 }

--- a/src/test/java/org/phoebus/channelfinder/service/external/ArchiverServiceTest.java
+++ b/src/test/java/org/phoebus/channelfinder/service/external/ArchiverServiceTest.java
@@ -1,0 +1,354 @@
+package org.phoebus.channelfinder.service.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.phoebus.channelfinder.exceptions.ArchiverServiceException;
+import org.phoebus.channelfinder.service.model.archiver.aa.ArchiveAction;
+import org.phoebus.channelfinder.service.model.archiver.aa.ArchivePVOptions;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiverServiceTest {
+
+  private static final String ARCHIVER_URL = "http://localhost:17665";
+  private MockRestServiceServer mockServer;
+  private ArchiverService archiverService;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+
+    archiverService = new ArchiverService(builder);
+    objectMapper = new ObjectMapper();
+
+    ReflectionTestUtils.setField(archiverService, "postSupportArchivers", List.of("test-archiver"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    mockServer.verify();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"other-archiver", "test-archiver"})
+  void testGetStatuses(String archiverAlias) throws JsonProcessingException {
+
+    Map<String, ArchivePVOptions> pvs = Map.of("pv1", new ArchivePVOptions());
+
+    List<Map<String, String>> expectedResponse =
+        List.of(Map.of("pv", "pv1", "status", "Being archived"));
+
+    if ("test-archiver".equals(archiverAlias)) {
+      mockServer
+          .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl/getPVStatus"))
+          .andExpect(method(HttpMethod.POST))
+          .andExpect(content().json("[\"pv1\"]"))
+          .andRespond(
+              withSuccess(
+                  objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
+    } else {
+      mockServer
+          .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl/getPVStatus?pv=pv1"))
+          .andExpect(method(HttpMethod.GET))
+          .andRespond(
+              withSuccess(
+                  objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
+    }
+
+    List<Map<String, String>> result =
+        archiverService.getStatuses(pvs, ARCHIVER_URL, archiverAlias);
+
+    assertEquals(1, result.size());
+    assertEquals("pv1", result.getFirst().get("pv"));
+    assertEquals("Being archived", result.getFirst().get("status"));
+  }
+
+  @Test
+  void testGetStatusesInvalidResponse() {
+
+    Map<String, ArchivePVOptions> pvs = Map.of("pv1", new ArchivePVOptions());
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl/getPVStatus?pv=pv1"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("invalid-json", MediaType.APPLICATION_JSON));
+
+    List<Map<String, String>> result =
+        archiverService.getStatuses(pvs, ARCHIVER_URL, "other-archiver");
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testSubmitBasicAction() throws JsonProcessingException {
+
+    List<String> pvs = List.of("pv1");
+    List<Map<String, String>> expectedResponse = List.of(Map.of("pv", "pv1", "status", "ok"));
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl"))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(content().json("[\"pv1\"]"))
+        .andRespond(
+            withSuccess(
+                objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
+
+    List<String> successfulPvs =
+        archiverService.submitBasicAction(pvs, ArchiveAction.NONE, ARCHIVER_URL);
+    assertEquals(1, successfulPvs.size());
+    assertEquals("pv1", successfulPvs.getFirst());
+  }
+
+  @Test
+  void testSubmitBasicActionStatusNotOk() throws JsonProcessingException {
+
+    List<String> pvs = List.of("pv1");
+    List<Map<String, String>> expectedResponse = List.of(Map.of("pv", "pv1", "status", "failed"));
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(
+            withSuccess(
+                objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
+
+    List<String> successfulPvs =
+        archiverService.submitBasicAction(pvs, ArchiveAction.NONE, ARCHIVER_URL);
+    assertTrue(successfulPvs.isEmpty());
+  }
+
+  @Test
+  void testSubmitBasicActionPartialFailure() throws JsonProcessingException {
+
+    List<String> pvs = List.of("pv1", "pv2");
+    List<Map<String, String>> expectedResponse =
+        List.of(Map.of("pv", "pv1", "status", "ok"), Map.of("pv", "pv2", "status", "failed"));
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(
+            withSuccess(
+                objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
+
+    List<String> successfulPvs =
+        archiverService.submitBasicAction(pvs, ArchiveAction.NONE, ARCHIVER_URL);
+    assertEquals(1, successfulPvs.size());
+    assertEquals("pv1", successfulPvs.getFirst());
+  }
+
+  @Test
+  void testSubmitBasicActionInvalidResponse() {
+
+    List<String> pvs = List.of("pv1");
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withSuccess("invalid-json", MediaType.APPLICATION_JSON));
+
+    assertThrows(
+        ArchiverServiceException.class,
+        () -> archiverService.submitBasicAction(pvs, ArchiveAction.NONE, ARCHIVER_URL));
+  }
+
+  @ParameterizedTest
+  @EnumSource(ArchiveAction.class)
+  void testConfigureAA(ArchiveAction action) throws JsonProcessingException {
+
+    ArchivePVOptions options = new ArchivePVOptions();
+    options.setPv("pv1");
+
+    Map<ArchiveAction, List<ArchivePVOptions>> archivePVS = new EnumMap<>(ArchiveAction.class);
+    archivePVS.put(ArchiveAction.ARCHIVE, List.of());
+    archivePVS.put(ArchiveAction.PAUSE, List.of());
+    archivePVS.put(ArchiveAction.RESUME, List.of());
+    archivePVS.put(action, List.of(options));
+
+    String status = action == ArchiveAction.ARCHIVE ? "Archive request submitted" : "ok";
+    List<Map<String, String>> expectedResponse = List.of(Map.of("pv", "pv1", "status", status));
+
+    if (action != ArchiveAction.NONE) {
+      String endpoint = action.getEndpoint();
+      String expectedBody;
+      if (action == ArchiveAction.ARCHIVE) {
+        expectedBody = objectMapper.writeValueAsString(List.of(options));
+      } else {
+        expectedBody = "[\"pv1\"]";
+      }
+
+      mockServer
+          .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl" + endpoint))
+          .andExpect(method(HttpMethod.POST))
+          .andExpect(content().json(expectedBody))
+          .andRespond(
+              withSuccess(
+                  objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
+    }
+
+    long count = archiverService.configureAA(archivePVS, ARCHIVER_URL);
+
+    assertEquals(action != ArchiveAction.NONE ? 1 : 0, count);
+  }
+
+  @Test
+  void testConfigureAAStatusNotOk() throws JsonProcessingException {
+
+    ArchivePVOptions options = new ArchivePVOptions();
+    options.setPv("pv1");
+    Map<ArchiveAction, List<ArchivePVOptions>> archivePVS =
+        Map.of(
+            ArchiveAction.ARCHIVE, List.of(options),
+            ArchiveAction.PAUSE, List.of(),
+            ArchiveAction.RESUME, List.of());
+
+    List<Map<String, String>> expectedResponse = List.of(Map.of("pv", "pv1", "status", "failed"));
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl" + ArchiveAction.ARCHIVE.getEndpoint()))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(
+            withSuccess(
+                objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
+
+    long count = archiverService.configureAA(archivePVS, ARCHIVER_URL);
+
+    assertEquals(0, count);
+  }
+
+  @Test
+  void testConfigureAAInvalidResponse() {
+
+    ArchivePVOptions options = new ArchivePVOptions();
+    options.setPv("pv1");
+    Map<ArchiveAction, List<ArchivePVOptions>> archivePVS =
+        Map.of(
+            ArchiveAction.ARCHIVE, List.of(options),
+            ArchiveAction.PAUSE, List.of(),
+            ArchiveAction.RESUME, List.of());
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl" + ArchiveAction.ARCHIVE.getEndpoint()))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withSuccess("invalid-json", MediaType.APPLICATION_JSON));
+
+    long count = archiverService.configureAA(archivePVS, ARCHIVER_URL);
+
+    assertEquals(0, count);
+  }
+
+  @Test
+  void testGetAAPolicies() throws JsonProcessingException {
+
+    Map<String, String> policies = Map.of("policy1", "desc1", "policy2", "desc2");
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl/getPolicyList"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(
+            withSuccess(objectMapper.writeValueAsString(policies), MediaType.APPLICATION_JSON));
+
+    List<String> result = archiverService.getAAPolicies(ARCHIVER_URL);
+
+    assertEquals(2, result.size());
+    assertTrue(result.contains("policy1"));
+    assertTrue(result.contains("policy2"));
+  }
+
+  @Test
+  void testGetAAPoliciesInvalidResponse() {
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl/getPolicyList"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("invalid-json", MediaType.APPLICATION_JSON));
+
+    List<String> result = archiverService.getAAPolicies(ARCHIVER_URL);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testSubmitActionWithRealResponseResume() {
+
+    List<String> pvs = List.of("PV1", "PV2");
+    String responseBody =
+        "[{\"pvName\":\"PV1\",\"engine_desc\":\"Successfully resumed the archiving of PV PV1\",\"engine_pvName\":\"PV1\",\"engine_status\":\"ok\",\"status\":\"ok\"},{\"pvName\":\"PV2\",\"engine_desc\":\"Successfully resumed the archiving of PV PV2\",\"engine_pvName\":\"PV2\",\"engine_status\":\"ok\",\"status\":\"ok\"}]";
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl" + ArchiveAction.RESUME.getEndpoint()))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(content().json("[\"PV1\",\"PV2\"]"))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    List<String> successfulPvs =
+        archiverService.submitBasicAction(pvs, ArchiveAction.RESUME, ARCHIVER_URL);
+    assertEquals(2, successfulPvs.size());
+    assertTrue(successfulPvs.contains("PV1"));
+    assertTrue(successfulPvs.contains("PV2"));
+  }
+
+  @Test
+  void testSubmitActionWithRealResponsePause() {
+
+    List<String> pvs = List.of("PV1");
+    String responseBody =
+        "[{\"pvName\":\"PV1\",\"engine_desc\":\"Successfully paused the archiving of PV PV1\",\"engine_pvName\":\"PV1\",\"engine_status\":\"ok\",\"etl_status\":\"ok\",\"etl_desc\":\"Successfully removed PV PV1 from the cluster\",\"etl_pvName\":\"PV1\",\"status\":\"ok\"}]";
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl" + ArchiveAction.PAUSE.getEndpoint()))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(content().json("[\"PV1\"]"))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    List<String> successfulPvs =
+        archiverService.submitBasicAction(pvs, ArchiveAction.PAUSE, ARCHIVER_URL);
+    assertEquals(1, successfulPvs.size());
+    assertTrue(successfulPvs.contains("PV1"));
+  }
+
+  @Test
+  void testSubmitActionWithRealResponseArchive() throws JsonProcessingException {
+
+    List<String> pvs = List.of("PV1");
+    ArchivePVOptions options = new ArchivePVOptions();
+    options.setPv("PV1");
+    List<ArchivePVOptions> payload = List.of(options);
+    String responseBody = "[{ \"pvName\": \"PV1\", \"status\": \"Archive request submitted\" }]";
+
+    mockServer
+        .expect(requestTo(ARCHIVER_URL + "/mgmt/bpl" + ArchiveAction.ARCHIVE.getEndpoint()))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(content().json(objectMapper.writeValueAsString(payload)))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    List<String> successfulPvs = archiverService.submitArchiveAction(pvs, payload, ARCHIVER_URL);
+    assertEquals(1, successfulPvs.size());
+    assertTrue(successfulPvs.contains("PV1"));
+  }
+}


### PR DESCRIPTION
Refactored the Archiver Client to make sure it can stream large requests.
Swapped to the Spring boot RestClient
Added a test ArchiverServiceTest
Reduced the scope of the AAProcessorIT tests to mock the ArchiverService

For future I'd like to use openapi definition from the archiver to generate a client, maybe that's a good codathon ticket.