### PR TITLE
Update test containers to 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,14 +161,8 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.19.3</version>
+            <version>1.21.4</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId> <!-- Need for running tests on mac -->

--- a/src/test/java/org/junit/rules/ExternalResource.java
+++ b/src/test/java/org/junit/rules/ExternalResource.java
@@ -1,8 +1,0 @@
-package org.junit.rules;
-
-/**
- * "Fake" class used as a replacement for Junit4-dependent classes. See more at: <a
- * href="https://github.com/testcontainers/testcontainers-java/issues/970">GenericContainer run from
- * Jupiter tests shouldn't require JUnit 4.x library on runtime classpath </a>.
- */
-public class ExternalResource {}

--- a/src/test/java/org/junit/rules/TestRule.java
+++ b/src/test/java/org/junit/rules/TestRule.java
@@ -1,9 +1,0 @@
-package org.junit.rules;
-
-/**
- * "Fake" class used as a replacement for Junit4-dependent classes. See more at: <a
- * href="https://github.com/testcontainers/testcontainers-java/issues/970">GenericContainer run from
- * Jupiter tests shouldn't require JUnit 4.x library on runtime classpath </a>.
- */
-@SuppressWarnings("unused")
-public interface TestRule {}

--- a/src/test/java/org/junit/runners/model/Statement.java
+++ b/src/test/java/org/junit/runners/model/Statement.java
@@ -1,9 +1,0 @@
-package org.junit.runners.model;
-
-/**
- * "Fake" class used as a replacement for Junit4-dependent classes. See more at: <a
- * href="https://github.com/testcontainers/testcontainers-java/issues/970">GenericContainer run from
- * Jupiter tests shouldn't require JUnit 4.x library on runtime classpath </a>.
- */
-@SuppressWarnings("unused")
-public class Statement {}


### PR DESCRIPTION
The dummy junit code is no longer needed as https://github.com/testcontainers/testcontainers-java/issues/970 has been fixed.