### PR TITLE
Swap to using Spring boot elastic auto configuration, fixes health check failing

### DIFF
--- a/src/main/java/org/phoebus/channelfinder/configuration/ElasticConfig.java
+++ b/src/main/java/org/phoebus/channelfinder/configuration/ElasticConfig.java
@@ -19,12 +19,11 @@ import co.elastic.clients.elasticsearch.indices.ExistsRequest;
 import co.elastic.clients.elasticsearch.indices.IndexSettings;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsResponse;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 // Jackson 2 required by elasticsearch-java 8.x JacksonJsonpMapper — migrate with ES 9
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 import java.io.IOException;
@@ -43,10 +42,9 @@ import org.apache.http.message.BasicHeader;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.phoebus.channelfinder.common.TextUtil;
-import org.phoebus.channelfinder.entity.Property;
-import org.phoebus.channelfinder.entity.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -56,15 +54,16 @@ import org.springframework.context.annotation.PropertySource;
  * @author Kunal Shroff {@literal <shroffk@bnl.gov>}
  */
 @Configuration
-@ConfigurationProperties(prefix = "elasticsearch")
 @ComponentScan(basePackages = {"org.phoebus.channelfinder"})
 @PropertySource(value = "classpath:application.properties")
-public class ElasticConfig implements ServletContextListener {
+public class ElasticConfig {
 
   private static final Logger logger = Logger.getLogger(ElasticConfig.class.getName());
 
-  private ElasticsearchClient searchClient;
-  private ElasticsearchClient indexClient;
+  // Used to retrieve the auto-configured ElasticsearchClient lazily in @PostConstruct,
+  // avoiding a circular dependency (this bean provides RestClient → auto-config builds
+  // ElasticsearchClient from it).
+  @Autowired private ApplicationContext applicationContext;
 
   @Value("${elasticsearch.network.host:localhost}")
   private String host;
@@ -119,51 +118,37 @@ public class ElasticConfig implements ServletContextListener {
     return ES_QUERY_SIZE;
   }
 
-  ObjectMapper objectMapper =
-      new ObjectMapper()
-          .addMixIn(Tag.class, Tag.OnlyTag.class)
-          .addMixIn(Property.class, Property.OnlyProperty.class);
+  public ElasticsearchClient getElasticsearchClient() {
+    return applicationContext.getBean(ElasticsearchClient.class);
+  }
 
-  private static ElasticsearchClient createClient(
-      ElasticsearchClient currentClient,
-      ObjectMapper objectMapper,
-      HttpHost[] httpHosts,
-      String createIndices,
-      ElasticConfig config) {
-    ElasticsearchClient client;
-    if (currentClient == null) {
-      // Create the low-level client
-      RestClientBuilder clientBuilder = RestClient.builder(httpHosts);
-      // Configure authentication
-      if (!config.authorizationHeader.isEmpty()) {
-        clientBuilder.setDefaultHeaders(
-            new Header[] {new BasicHeader("Authorization", config.authorizationHeader)});
-        if (!config.username.isEmpty() || !config.password.isEmpty()) {
-          logger.warning(
-              "elasticsearch.authorization_header is set, ignoring elasticsearch.username and elasticsearch.password.");
-        }
-      } else if (!config.username.isEmpty() || !config.password.isEmpty()) {
-        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-        credentialsProvider.setCredentials(
-            AuthScope.ANY, new UsernamePasswordCredentials(config.username, config.password));
-        clientBuilder.setHttpClientConfigCallback(
-            httpClientBuilder ->
-                httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+  /**
+   * Provides the low-level Elasticsearch {@link RestClient} built from the {@code elasticsearch.*}
+   * connection properties. Spring Boot's {@code ElasticsearchClientAutoConfiguration} detects this
+   * bean and uses it to auto-configure {@code ElasticsearchTransport} and {@code
+   * ElasticsearchClient}, which in turn activates the {@code /actuator/health} Elasticsearch
+   * indicator.
+   */
+  @Bean
+  public RestClient restClient() {
+    RestClientBuilder clientBuilder = RestClient.builder(getHttpHosts());
+    if (!authorizationHeader.isEmpty()) {
+      clientBuilder.setDefaultHeaders(
+          new Header[] {new BasicHeader("Authorization", authorizationHeader)});
+      if (!username.isEmpty() || !password.isEmpty()) {
+        logger.warning(
+            "elasticsearch.authorization.header is set, ignoring"
+                + " elasticsearch.authorization.username and elasticsearch.authorization.password.");
       }
-      RestClient httpClient = clientBuilder.build();
-
-      // Create the Java API Client with the same low level client
-      ElasticsearchTransport transport =
-          new RestClientTransport(httpClient, new JacksonJsonpMapper(objectMapper));
-
-      client = new ElasticsearchClient(transport);
-    } else {
-      client = currentClient;
+    } else if (!username.isEmpty() || !password.isEmpty()) {
+      final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+      credentialsProvider.setCredentials(
+          AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+      clientBuilder.setHttpClientConfigCallback(
+          httpClientBuilder ->
+              httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
     }
-    if (Boolean.parseBoolean(createIndices)) {
-      config.elasticIndexValidation(client);
-    }
-    return client;
+    return clientBuilder.build();
   }
 
   private HttpHost[] getHttpHosts() {
@@ -173,47 +158,33 @@ public class ElasticConfig implements ServletContextListener {
     boolean portIsDefault = (port == 9200);
     if (hostUrlsIsDefault && (!hostIsDefault || !portIsDefault)) {
       logger.warning(
-          "Specifying elasticsearch.network.host and elasticsearch.http.port is deprecated, please consider using elasticsearch.host_urls instead.");
+          "Specifying elasticsearch.network.host and elasticsearch.http.port is deprecated,"
+              + " please consider using elasticsearch.host_urls instead.");
       return new HttpHost[] {new HttpHost(host, port)};
     } else {
       if (!hostIsDefault) {
         logger.warning(
-            "Only one of elasticsearch.host_urls and elasticsearch.network.host can be set, ignoring elasticsearch.network.host.");
+            "Only one of elasticsearch.host_urls and elasticsearch.network.host can be set,"
+                + " ignoring elasticsearch.network.host.");
       }
       if (!portIsDefault) {
         logger.warning(
-            "Only one of elasticsearch.host_urls and elasticsearch.http.port can be set, ignoring elasticsearch.http.port.");
+            "Only one of elasticsearch.host_urls and elasticsearch.http.port can be set,"
+                + " ignoring elasticsearch.http.port.");
       }
       return Arrays.stream(httpHostUrls).map(HttpHost::create).toArray(HttpHost[]::new);
     }
   }
 
-  @Bean({"searchClient"})
-  public ElasticsearchClient getSearchClient() {
-    searchClient = createClient(searchClient, objectMapper, getHttpHosts(), createIndices, this);
-    return searchClient;
-  }
-
-  @Bean({"indexClient"})
-  public ElasticsearchClient getIndexClient() {
-    indexClient = createClient(indexClient, objectMapper, getHttpHosts(), createIndices, this);
-    return indexClient;
-  }
-
-  @Override
-  public void contextInitialized(ServletContextEvent sce) {
-    logger.log(Level.INFO, "Initializing a new Transport clients.");
-  }
-
-  @Override
-  public void contextDestroyed(ServletContextEvent sce) {
-    logger.log(Level.INFO, "Closing the default Transport clients.");
-    if (searchClient != null) searchClient.shutdown();
-    if (indexClient != null) indexClient.shutdown();
+  @PostConstruct
+  public void init() {
+    if (Boolean.parseBoolean(createIndices)) {
+      elasticIndexValidation(applicationContext.getBean(ElasticsearchClient.class));
+    }
   }
 
   /**
-   * Create the olog indices and templates if they don't exist
+   * Create the ChannelFinder indices and templates if they don't exist
    *
    * @param client client connected to elasticsearch
    */

--- a/src/main/java/org/phoebus/channelfinder/configuration/PopulateDBConfiguration.java
+++ b/src/main/java/org/phoebus/channelfinder/configuration/PopulateDBConfiguration.java
@@ -29,7 +29,6 @@ import org.phoebus.channelfinder.entity.Channel;
 import org.phoebus.channelfinder.entity.Property;
 import org.phoebus.channelfinder.entity.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
@@ -113,9 +112,7 @@ public class PopulateDBConfiguration {
 
   @Autowired ElasticConfig esService;
 
-  @Autowired
-  @Qualifier("indexClient")
-  ElasticsearchClient client;
+  @Autowired ElasticsearchClient client;
 
   public static final ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/org/phoebus/channelfinder/repository/ChannelRepository.java
+++ b/src/main/java/org/phoebus/channelfinder/repository/ChannelRepository.java
@@ -84,7 +84,7 @@ public class ChannelRepository implements CrudRepository<Channel, String> {
 
   public ChannelRepository(
       ElasticConfig esService,
-      @Qualifier("indexClient") ElasticsearchClient client,
+      ElasticsearchClient client,
       LegacyApiProperties legacyApiProperties) {
     this.esService = esService;
     this.client = client;

--- a/src/main/java/org/phoebus/channelfinder/repository/PropertyRepository.java
+++ b/src/main/java/org/phoebus/channelfinder/repository/PropertyRepository.java
@@ -37,7 +37,6 @@ import org.phoebus.channelfinder.entity.Channel;
 import org.phoebus.channelfinder.entity.Property;
 import org.phoebus.channelfinder.entity.Property.OnlyNameOwnerProperty;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.http.HttpStatus;
@@ -54,9 +53,7 @@ public class PropertyRepository implements CrudRepository<Property, String> {
 
   private static final Logger logger = Logger.getLogger(PropertyRepository.class.getName());
 
-  @Autowired
-  @Qualifier("indexClient")
-  ElasticsearchClient client;
+  @Autowired ElasticsearchClient client;
 
   @Autowired ElasticConfig esService;
 

--- a/src/main/java/org/phoebus/channelfinder/repository/TagRepository.java
+++ b/src/main/java/org/phoebus/channelfinder/repository/TagRepository.java
@@ -38,7 +38,6 @@ import org.phoebus.channelfinder.entity.Channel;
 import org.phoebus.channelfinder.entity.Tag;
 import org.phoebus.channelfinder.entity.Tag.OnlyTag;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.http.HttpStatus;
@@ -57,9 +56,7 @@ public class TagRepository implements CrudRepository<Tag, String> {
 
   @Autowired ElasticConfig esService;
 
-  @Autowired
-  @Qualifier("indexClient")
-  ElasticsearchClient client;
+  @Autowired ElasticsearchClient client;
 
   @Autowired ChannelRepository channelRepository;
 

--- a/src/main/java/org/phoebus/channelfinder/service/InfoService.java
+++ b/src/main/java/org/phoebus/channelfinder/service/InfoService.java
@@ -5,7 +5,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.phoebus.channelfinder.configuration.ElasticConfig;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import tools.jackson.core.JacksonException;
@@ -21,13 +22,13 @@ public class InfoService {
   private static final ObjectMapper objectMapper =
       JsonMapper.builder().enable(SerializationFeature.INDENT_OUTPUT).build();
 
-  private final ElasticConfig esService;
+  private final ElasticsearchClient elasticsearchClient;
 
   @Value("${channelfinder.version:unknown}")
   private String version;
 
-  public InfoService(ElasticConfig esService) {
-    this.esService = esService;
+  public InfoService(ElasticsearchClient elasticsearchClient) {
+    this.elasticsearchClient = elasticsearchClient;
   }
 
   public String info() {
@@ -37,8 +38,7 @@ public class InfoService {
 
     Map<String, String> elasticInfo = new LinkedHashMap<>();
     try {
-      var client = esService.getSearchClient();
-      var response = client.info();
+      var response = elasticsearchClient.info();
       elasticInfo.put("status", "Connected");
       elasticInfo.put("clusterName", response.clusterName());
       elasticInfo.put("clusterUuid", response.clusterUuid());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,8 +83,8 @@ elasticsearch.http.port=9200
 # Elasticsearch sever. This can be used for authentication using tokens or API
 # keys.
 #
-# For example, for token authentication, set this to ?Bearer abcd1234?, where
-# ?abcd1234? is the token. For API key authentication, set this to the Base64
+# For example, for token authentication, set this to "Bearer abcd1234", where
+# "abcd1234" is the token. For API key authentication, set this to the Base64
 # encoded version of the concatenation of the API key ID and the API key
 # secret, separated by a colon. See
 # https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.12/_other_authentication_methods.html

--- a/src/test/java/org/phoebus/channelfinder/ElasticConfigIT.java
+++ b/src/test/java/org/phoebus/channelfinder/ElasticConfigIT.java
@@ -20,8 +20,8 @@ public class ElasticConfigIT {
           elasticConfig.getES_TAG_INDEX()
         };
     for (String index : indexes) {
-      if (elasticConfig.getSearchClient().indices().exists(b -> b.index(index)).value()) {
-        elasticConfig.getSearchClient().indices().delete(b -> b.index(index));
+      if (elasticConfig.getElasticsearchClient().indices().exists(b -> b.index(index)).value()) {
+        elasticConfig.getElasticsearchClient().indices().delete(b -> b.index(index));
       }
     }
   }
@@ -35,6 +35,6 @@ public class ElasticConfigIT {
    * @param elasticConfig Bean with configuration
    */
   static void setUp(ElasticConfig elasticConfig) {
-    elasticConfig.elasticIndexValidation(elasticConfig.getSearchClient());
+    elasticConfig.elasticIndexValidation(elasticConfig.getElasticsearchClient());
   }
 }


### PR DESCRIPTION
This uses a more standard (although not completely standard) way of configuring the elastic search client.

Does this by creating a RestClient bean rather than the per index elastic beans. 

- This is then autowired in the healthcheck against elasticsearch making sure the health of channelfinder relies on elasticsearch health.
- As well as the ElasticSearchClient is auto matically wired by Spring Boots auto elasticsearch configuration.

Note that I could have gone even more standard by autowiring the RestClient from the Spring Boot auto configuration, but that would have mean the application.properties properties for configuring the connection would have to have a new prefix from elasticsearch to spring.elasticsearch.
