### PR TITLE
fix(web): drop not-found log noise - FINE without stack trace

### DIFF
--- a/src/main/java/org/phoebus/channelfinder/web/v0/V0ExceptionHandler.java
+++ b/src/main/java/org/phoebus/channelfinder/web/v0/V0ExceptionHandler.java
@@ -33,21 +33,21 @@ public class V0ExceptionHandler {
   @ExceptionHandler(ChannelNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public ResponseStatusException handleChannelNotFound(ChannelNotFoundException ex) {
-    logger.log(Level.WARNING, ex.getMessage(), ex);
+    logger.log(Level.FINE, ex::getMessage);
     return new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
   }
 
   @ExceptionHandler(TagNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public ResponseStatusException handleTagNotFound(TagNotFoundException ex) {
-    logger.log(Level.WARNING, ex.getMessage(), ex);
+    logger.log(Level.FINE, ex::getMessage);
     return new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
   }
 
   @ExceptionHandler(PropertyNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public ResponseStatusException handlePropertyNotFound(PropertyNotFoundException ex) {
-    logger.log(Level.WARNING, ex.getMessage(), ex);
+    logger.log(Level.FINE, ex::getMessage);
     return new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
   }
 


### PR DESCRIPTION
A misbehaving client hammering a non-existent channel generated thousands of WARNING entries, drowning out real server-side failures. 404s are client errors; the HTTP response is sufficient, and the audit log already records every lookup at INFO. FINE keeps the messages available under debug logging without polluting production logs.