### PR TITLE
improve the channel validation pipeline

### DIFF
--- a/src/main/java/org/phoebus/channelfinder/service/ChannelService.java
+++ b/src/main/java/org/phoebus/channelfinder/service/ChannelService.java
@@ -184,74 +184,63 @@ public class ChannelService {
         .collect(Collectors.toMap(Channel::getName, c -> c));
   }
 
+  /**
+   * Validates one channel payload.
+   *
+   * <p>Validation requires a non-empty channel name and owner, verifies that all referenced tags
+   * and properties exist, and rejects null/empty property values.
+   *
+   * @param channel channel to validate
+   */
   private void validateChannel(Channel channel) {
-    if (channel.getName() == null || channel.getName().isEmpty()) {
-      throw new ChannelValidationException(
-          MessageFormat.format(TextUtil.CHANNEL_NAME_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
-    }
-    if (channel.getOwner() == null || channel.getOwner().isEmpty()) {
-      throw new ChannelValidationException(
-          MessageFormat.format(TextUtil.CHANNEL_OWNER_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
-    }
-    for (Tag tag : channel.getTags()) {
-      if (!tagRepository.existsById(tag.getName())) {
-        throw new TagNotFoundException(tag.getName());
-      }
-    }
-    checkPropertyValues(channel);
+    validateChannels(List.of(channel));
   }
 
+  /**
+   * Validates each channel payload in the provided iterable.
+   *
+   * <p>For every channel, validation requires a non-empty name and owner, verifies that all
+   * referenced tags and properties exist, and rejects null/empty property values.
+   *
+   * @param channels channels to validate
+   */
   private void validateChannels(Iterable<Channel> channels) {
-    List<String> existingProperties =
-        StreamSupport.stream(propertyRepository.findAll().spliterator(), true)
+    Iterable<Tag> existingTags = tagRepository.findAll();
+    List<String> existingTagNames =
+        StreamSupport.stream(existingTags.spliterator(), true).map(Tag::getName).toList();
+
+    Iterable<Property> existingProperties = propertyRepository.findAll();
+    List<String> existingPropertyNames =
+        StreamSupport.stream(existingProperties.spliterator(), true)
             .map(Property::getName)
             .toList();
-    List<String> existingTags =
-        StreamSupport.stream(tagRepository.findAll().spliterator(), true)
-            .map(Tag::getName)
-            .toList();
+
     for (Channel channel : channels) {
-      validateChannelAgainst(channel, existingTags, existingProperties);
+      if (channel.getName() == null || channel.getName().isEmpty()) {
+        throw new ChannelValidationException(
+            MessageFormat.format(TextUtil.CHANNEL_NAME_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
+      }
+      if (channel.getOwner() == null || channel.getOwner().isEmpty()) {
+        throw new ChannelValidationException(
+            MessageFormat.format(TextUtil.CHANNEL_OWNER_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
+      }
+      for (Tag tag : channel.getTags()) {
+        if (!existingTagNames.contains(tag.getName())) {
+          throw new TagNotFoundException(tag.getName());
+        }
+      }
+      List<String> propNames = channel.getProperties().stream().map(Property::getName).toList();
+      for (String propName : propNames) {
+        if (!existingPropertyNames.contains(propName)) {
+          throw new PropertyNotFoundException(propName);
+        }
+      }
+      List<String> propValues = channel.getProperties().stream().map(Property::getValue).toList();
+      checkPropertyValues(propNames, propValues);
     }
   }
 
-  private void validateChannelAgainst(
-      Channel channel, List<String> existingTags, List<String> existingProperties) {
-    if (channel.getName() == null || channel.getName().isEmpty()) {
-      throw new ChannelValidationException(
-          MessageFormat.format(TextUtil.CHANNEL_NAME_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
-    }
-    if (channel.getOwner() == null || channel.getOwner().isEmpty()) {
-      throw new ChannelValidationException(
-          MessageFormat.format(TextUtil.CHANNEL_OWNER_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
-    }
-    for (Tag tag : channel.getTags()) {
-      if (!existingTags.contains(tag.getName())) {
-        throw new TagNotFoundException(tag.getName());
-      }
-    }
-    List<String> propNames = channel.getProperties().stream().map(Property::getName).toList();
-    List<String> propValues = channel.getProperties().stream().map(Property::getValue).toList();
-    for (String propName : propNames) {
-      if (!existingProperties.contains(propName)) {
-        throw new PropertyNotFoundException(propName);
-      }
-    }
-    checkValues(propNames, propValues);
-  }
-
-  private void checkPropertyValues(Channel channel) {
-    List<String> propNames = channel.getProperties().stream().map(Property::getName).toList();
-    List<String> propValues = channel.getProperties().stream().map(Property::getValue).toList();
-    for (String propName : propNames) {
-      if (!propertyRepository.existsById(propName)) {
-        throw new PropertyNotFoundException(propName);
-      }
-    }
-    checkValues(propNames, propValues);
-  }
-
-  private void checkValues(List<String> propNames, List<String> propValues) {
+  private void checkPropertyValues(List<String> propNames, List<String> propValues) {
     for (int i = 0; i < propValues.size(); i++) {
       String value = propValues.get(i);
       if (value == null || value.isEmpty()) {

--- a/src/main/java/org/phoebus/channelfinder/service/ChannelService.java
+++ b/src/main/java/org/phoebus/channelfinder/service/ChannelService.java
@@ -208,42 +208,87 @@ public class ChannelService {
    */
   private void validateChannels(Iterable<Channel> channels) {
     Iterable<Tag> existingTags = tagRepository.findAll();
-    Set<String> existingTagNames =
-            StreamSupport.stream(existingTags.spliterator(), true)
-                    .map(Tag::getName).collect(Collectors.toCollection(HashSet::new));
-
     Iterable<Property> existingProperties = propertyRepository.findAll();
-    Set<String> existingPropertyNames =
-            StreamSupport.stream(existingProperties.spliterator(), true)
-                    .map(Property::getName)
-                    .collect(Collectors.toCollection(HashSet::new));
 
     for (Channel channel : channels) {
-      if (channel.getName() == null || channel.getName().isEmpty()) {
-        throw new ChannelValidationException(
-            MessageFormat.format(TextUtil.CHANNEL_NAME_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
-      }
-      if (channel.getOwner() == null || channel.getOwner().isEmpty()) {
-        throw new ChannelValidationException(
-            MessageFormat.format(TextUtil.CHANNEL_OWNER_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
-      }
-      for (Tag tag : channel.getTags()) {
-        if (!existingTagNames.contains(tag.getName())) {
-          throw new TagNotFoundException(tag.getName());
-        }
-      }
-      List<String> propNames = channel.getProperties().stream().map(Property::getName).toList();
-      for (String propName : propNames) {
-        if (!existingPropertyNames.contains(propName)) {
-          throw new PropertyNotFoundException(propName);
-        }
-      }
-      List<String> propValues = channel.getProperties().stream().map(Property::getValue).toList();
-      checkPropertyValues(propNames, propValues);
+      validateNotEmpty(channel);
+      validateTagsExist(channel, existingTags);
+      validatePropertiesExist(channel, existingProperties);
+      validatePropertyValues(channel);
     }
   }
 
-  private void checkPropertyValues(List<String> propNames, List<String> propValues) {
+  /**
+   * Validates that channel name and owner are non-null and non-empty.
+   *
+   * @param channel the channel to validate
+   * @throws ChannelValidationException if name or owner is null or empty
+   */
+  private void validateNotEmpty(Channel channel) {
+    if (channel.getName() == null || channel.getName().isEmpty()) {
+      throw new ChannelValidationException(
+          MessageFormat.format(TextUtil.CHANNEL_NAME_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
+    }
+    if (channel.getOwner() == null || channel.getOwner().isEmpty()) {
+      throw new ChannelValidationException(
+          MessageFormat.format(TextUtil.CHANNEL_OWNER_CANNOT_BE_NULL_OR_EMPTY, channel.toLog()));
+    }
+  }
+
+  /**
+   * Validates that all referenced tags in the channel exist in ChannelFinder.
+   *
+   * @param channel the channel to validate
+   * @param existingTags iterable of existing tags in ChannelFinder
+   * @throws TagNotFoundException if any referenced tag does not exist
+   */
+  private void validateTagsExist(Channel channel, Iterable<Tag> existingTags) {
+    Set<String> existingTagNames =
+        StreamSupport.stream(existingTags.spliterator(), false)
+            .map(Tag::getName)
+            .collect(Collectors.toCollection(HashSet::new));
+
+    for (Tag tag : channel.getTags()) {
+      if (!existingTagNames.contains(tag.getName())) {
+        throw new TagNotFoundException(tag.getName());
+      }
+    }
+  }
+
+  /**
+   * Validates that all referenced properties in the channel exist in ChannelFinder.
+   *
+   * @param channel the channel to validate
+   * @param existingProperties iterable of existing properties in ChannelFinder
+   * @throws PropertyNotFoundException if any referenced property does not exist
+   */
+  private void validatePropertiesExist(Channel channel, Iterable<Property> existingProperties) {
+    Set<String> existingPropertyNames =
+        StreamSupport.stream(existingProperties.spliterator(), false)
+            .map(Property::getName)
+            .collect(Collectors.toCollection(HashSet::new));
+
+    List<String> propNames =
+        channel.getProperties().stream().map(Property::getName).toList();
+    for (String propName : propNames) {
+      if (!existingPropertyNames.contains(propName)) {
+        throw new PropertyNotFoundException(propName);
+      }
+    }
+  }
+
+  /**
+   * Validates that all property values in the channel are non-null and non-empty.
+   *
+   * @param channel the channel to validate
+   * @throws ChannelValidationException if any property value is null or empty
+   */
+  private void validatePropertyValues(Channel channel) {
+    List<String> propNames =
+        channel.getProperties().stream().map(Property::getName).toList();
+    List<String> propValues =
+        channel.getProperties().stream().map(Property::getValue).toList();
+
     for (int i = 0; i < propValues.size(); i++) {
       String value = propValues.get(i);
       if (value == null || value.isEmpty()) {

--- a/src/main/java/org/phoebus/channelfinder/service/ChannelService.java
+++ b/src/main/java/org/phoebus/channelfinder/service/ChannelService.java
@@ -2,9 +2,11 @@ package org.phoebus.channelfinder.service;
 
 import com.google.common.collect.Lists;
 import java.text.MessageFormat;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -206,14 +208,15 @@ public class ChannelService {
    */
   private void validateChannels(Iterable<Channel> channels) {
     Iterable<Tag> existingTags = tagRepository.findAll();
-    List<String> existingTagNames =
-        StreamSupport.stream(existingTags.spliterator(), true).map(Tag::getName).toList();
+    Set<String> existingTagNames =
+            StreamSupport.stream(existingTags.spliterator(), true)
+                    .map(Tag::getName).collect(Collectors.toCollection(HashSet::new));
 
     Iterable<Property> existingProperties = propertyRepository.findAll();
-    List<String> existingPropertyNames =
-        StreamSupport.stream(existingProperties.spliterator(), true)
-            .map(Property::getName)
-            .toList();
+    Set<String> existingPropertyNames =
+            StreamSupport.stream(existingProperties.spliterator(), true)
+                    .map(Property::getName)
+                    .collect(Collectors.toCollection(HashSet::new));
 
     for (Channel channel : channels) {
       if (channel.getName() == null || channel.getName().isEmpty()) {

--- a/src/test/java/org/phoebus/channelfinder/service/ChannelServiceTest.java
+++ b/src/test/java/org/phoebus/channelfinder/service/ChannelServiceTest.java
@@ -79,7 +79,7 @@ class ChannelServiceTest {
   void createChannel_nonExistentTag_throwsTagNotFoundException() {
     Tag tag = new Tag("missing-tag", "owner");
     Channel channel = new Channel("ch", "owner", List.of(), List.of(tag));
-    when(tagRepository.existsById("missing-tag")).thenReturn(false);
+    when(tagRepository.findAll()).thenReturn(List.of());
 
     assertThrows(TagNotFoundException.class, () -> channelService.create("ch", channel));
   }
@@ -88,7 +88,8 @@ class ChannelServiceTest {
   void createChannel_nonExistentProperty_throwsPropertyNotFoundException() {
     Property prop = new Property("missing-prop", "owner", "val");
     Channel channel = new Channel("ch", "owner", List.of(prop), List.of());
-    when(propertyRepository.existsById("missing-prop")).thenReturn(false);
+    when(tagRepository.findAll()).thenReturn(List.of());
+    when(propertyRepository.findAll()).thenReturn(List.of());
 
     assertThrows(PropertyNotFoundException.class, () -> channelService.create("ch", channel));
   }
@@ -97,7 +98,8 @@ class ChannelServiceTest {
   void createChannel_nullPropertyValue_throwsValidationException() {
     Property prop = new Property("prop1", "owner", null);
     Channel channel = new Channel("ch", "owner", List.of(prop), List.of());
-    when(propertyRepository.existsById("prop1")).thenReturn(true);
+    when(tagRepository.findAll()).thenReturn(List.of());
+    when(propertyRepository.findAll()).thenReturn(List.of(prop));
 
     assertThrows(ChannelValidationException.class, () -> channelService.create("ch", channel));
   }
@@ -106,7 +108,8 @@ class ChannelServiceTest {
   void createChannel_emptyPropertyValue_throwsValidationException() {
     Property prop = new Property("prop1", "owner", "");
     Channel channel = new Channel("ch", "owner", List.of(prop), List.of());
-    when(propertyRepository.existsById("prop1")).thenReturn(true);
+    when(tagRepository.findAll()).thenReturn(List.of());
+    when(propertyRepository.findAll()).thenReturn(List.of(prop));
 
     assertThrows(ChannelValidationException.class, () -> channelService.create("ch", channel));
   }
@@ -129,8 +132,6 @@ class ChannelServiceTest {
     Property prop = new Property("prop1", "owner", "value");
     Channel channel = new Channel("ch", "owner", List.of(prop), List.of(tag));
     when(authorizationService.isAuthorizedOwner(any(), any(Channel.class))).thenReturn(true);
-    when(tagRepository.existsById("tag1")).thenReturn(true);
-    when(propertyRepository.existsById("prop1")).thenReturn(true);
     when(channelRepository.findById("ch")).thenReturn(Optional.empty());
     when(channelRepository.index(any())).thenReturn(channel);
     when(propertyRepository.findAll()).thenReturn(List.of(prop));


### PR DESCRIPTION
- Refactored validation in `ChannelService` to reduce duplication:
  - `validateChannel(...)` now routes through `validateChannels(List.of(channel))`
  - all channel validation logic is centralized in one flow ( previous there were 2 pathways with a bunch of duplicate code )

- Improved validation efficiency:
  - `validateChannels(...)` loads existing tags/properties once per call
  - each channel is validated against these in-memory snapshots
  - **avoids repeated Elasticsearch existence checks (`existsById`) for every tag/property**