### PR TITLE
maven: fix the version of Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>copy</id>
@@ -449,6 +450,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
+                        <version>3.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
This ensures the reproducibility of the build environment, by always using the same version of the plugins.

Note that previously the version of the `maven-source-plugin` used wasn't `3.4.0`, but the non-final `4.0.0-beta-1`.